### PR TITLE
Added release-package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,13 +1,13 @@
 name: Publish a NuGet package
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths: 
       - 'src/LEGO.AsyncAPI/**'
       - '!**/*.md'
   pull_request:
     types: [closed]
-    branches: [ master ]
+    branches: [ main ]
     paths: 
       - 'src/LEGO.AsyncAPI/**'
       - '!**/*.md'
@@ -23,7 +23,7 @@ jobs:
         with:
           source-url: https://nuget.pkg.github.com/LEGO/index.json
         env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}   
+          NUGET_AUTH_TOKEN: ${{secrets.LEGO_GITHUB_DOCKER_REGISTR_READ_WRITE_DELETE_TOKEN}}   
       - name: Build LEGO.AsyncAPI project and pack NuGet package
         run: dotnet pack src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj -c Release -o out
 #     next step to be uncommented when LEGO.AsyncAPI is complete


### PR DESCRIPTION
This is to add a workflow to publish to Lego GitHub Package registry.

Actual publishing is commented out for now, until Lego.AsyncAPI project is complete.