### PR TITLE
Made Actions use GH_TOKEN instead of self-made secret

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           source-url: https://nuget.pkg.github.com/LEGO/index.json
         env:
-          NUGET_AUTH_TOKEN: ${{secrets.LEGO_GITHUB_DOCKER_REGISTR_READ_WRITE_DELETE_TOKEN}}   
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}   
       - name: Build LEGO.AsyncAPI project and pack NuGet package
         run: dotnet pack src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj -c Release -o out
 #     next step to be uncommented when LEGO.AsyncAPI is complete


### PR DESCRIPTION
Just seen @giovannidegani 's message on Teams claiming this is no longer required - I guess out it goes!

https://teams.microsoft.com/l/message/19:b3ed027d0a4f4b7fbaf38939ca048a2c@thread.skype/1646064354175?tenantId=1d063515-6cad-4195-9486-ea65df456faa&groupId=ecf9587b-7f13-48da-85fa-d6e62472a771&parentMessageId=1646062233818&teamName=IT%20at%20the%20LEGO%20Group&channelName=GitHub&createdTime=1646064354175