### PR TITLE
Version number cannot be larger than 2147483647

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -26,10 +26,14 @@ jobs:
         with:
           source-url: https://nuget.pkg.github.com/LEGO/index.json
         env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}   
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}    
+       
+      - name: Get last char shortened GITHUB_RUN_ID
+        id: slug
+        run: echo "::set-output name=github_run_id::$(echo ${$GITHUB_RUN_ID} | cut -c1-9)"
       
       - name: Build ${{ matrix.package-name }} project and pack NuGet package
-        run: dotnet pack src/${{ matrix.package-name }}/${{ matrix.package-name }}.csproj -c Release -o out-${{ matrix.package-name }} -p:PackageVersion=0.1.$GITHUB_RUN_ID.$GITHUB_RUN_NUMBER-prerelease
+        run: dotnet pack src/${{ matrix.package-name }}/${{ matrix.package-name }}.csproj -c Release -o out-${{ matrix.package-name }} -p:PackageVersion=0.1.${{ steps.slug.outputs.github_run_id }}.$GITHUB_RUN_NUMBER-prerelease
 
       - name: Push generated package to GitHub Packages registry
         run: dotnet nuget push out-${{ matrix.package-name }}/*.nupkg --skip-duplicate -n --api-key ${{secrets.GITHUB_TOKEN}}      


### PR DESCRIPTION
Unblocks #19 

 GITHUB_RUN_ID is larger than that (currently ~2.190.000.000), hence removing last digid from GITHUB_RUN_ID  to fit in version and still use it as a simple way to bump package version number.