### PR TITLE
fix: schemaformat is now handled as an enum

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiMessageDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiMessageDeserializer.cs
@@ -71,7 +71,7 @@ namespace LEGO.AsyncAPI.Readers
                 return SchemaFormat.AsyncApi;
             }
 
-            var schemaFormat = format.GetEnumFromDisplayName<SchemaFormat>();
+            var schemaFormat = format.GetEnumFromDisplayNameOrDefault<SchemaFormat>(SchemaFormat.Unsupported);
             if (schemaFormat == SchemaFormat.Unsupported)
             {
                 throw new AsyncApiException($"SchemaFormat '{format}' is not supported");

--- a/src/LEGO.AsyncAPI/Models/AsyncApiMessage.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiMessage.cs
@@ -38,7 +38,7 @@ namespace LEGO.AsyncAPI.Models
         /// <remarks>
         /// If omitted, implementations should parse the payload as a Schema object.
         /// </remarks>
-        public SchemaFormat SchemaFormat { get; set; } = SchemaFormat.AsyncApi;
+        public SchemaFormat? SchemaFormat { get; set; }
 
         /// <summary>
         /// the content type to use when encoding/decoding a message's payload.
@@ -126,7 +126,7 @@ namespace LEGO.AsyncAPI.Models
             writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.SerializeV2(w));
             writer.WriteOptionalObject(AsyncApiConstants.Payload, this.Payload, (w, p) => p.SerializeV2(w));
             writer.WriteOptionalObject(AsyncApiConstants.CorrelationId, this.CorrelationId, (w, c) => c.SerializeV2(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.SchemaFormat, this.SchemaFormat.GetDisplayName());
+            writer.WriteOptionalProperty(AsyncApiConstants.SchemaFormat, this.SchemaFormat == null ? null : this.SchemaFormat.GetDisplayName());
             writer.WriteOptionalProperty(AsyncApiConstants.ContentType, this.ContentType);
             writer.WriteOptionalProperty(AsyncApiConstants.Name, this.Name);
             writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);

--- a/src/LEGO.AsyncAPI/Models/SchemaFormat.cs
+++ b/src/LEGO.AsyncAPI/Models/SchemaFormat.cs
@@ -6,8 +6,6 @@ namespace LEGO.AsyncAPI.Models
 
     public enum SchemaFormat
     {
-        Unsupported,
-
         [Display("application/vnd.aai.asyncapi;version=2.5.0")]
         AsyncApi,
 
@@ -17,10 +15,12 @@ namespace LEGO.AsyncAPI.Models
         [Display("application/vnd.aai.asyncapi+yaml;version=2.5.0")]
         AsyncApiYaml,
 
-        [Display("application/vnd.aai.asyncapi+json;version=2.5.0")]
+        [Display("application/schema+json;version=draft-07")]
         JsonSchemaJson,
 
-        [Display("application/vnd.aai.asyncapi+yaml;version=2.5.0")]
+        [Display("application/schema+yaml;version=draft-07")]
         JsonSchemaYaml,
+
+        Unsupported = 99999999,
     }
 }

--- a/src/LEGO.AsyncAPI/Writers/StringExtensions.cs
+++ b/src/LEGO.AsyncAPI/Writers/StringExtensions.cs
@@ -33,5 +33,27 @@ namespace LEGO.AsyncAPI.Writers
 
             return default;
         }
+
+        public static T GetEnumFromDisplayNameOrDefault<T>(this string displayName, T defaultValue)
+        {
+            var type = typeof(T);
+            if (!type.IsEnum)
+            {
+                return default;
+            }
+
+            foreach (var value in Enum.GetValues(type))
+            {
+                var field = type.GetField(value.ToString());
+
+                var displayAttribute = (DisplayAttribute)field.GetCustomAttribute(typeof(DisplayAttribute));
+                if (displayAttribute != null && displayAttribute.Name == displayName)
+                {
+                    return (T)value;
+                }
+            }
+
+            return defaultValue;
+        }
     }
 }

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -759,7 +759,6 @@ channels:
               description: correlationDescription
               location: correlationLocation
               x-extension: value
-            schemaFormat: schemaFormat
             contentType: contentType
             name: messageName
             title: messageTitle

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiReaderTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiReaderTests.cs
@@ -10,121 +10,13 @@ namespace LEGO.AsyncAPI.Tests
 
     public class AsyncApiReaderTests
     {
-      [Test]
-      public void Read_WithFullSpec_Deserializes()
-      {
-        var yaml = @"asyncapi: 2.3.0
-info:
-  title: AMMA
-  version: 1.0.0
-  x-audience: component-internal
-  x-application-id: APP-12345
-  description: |
-    Sending AMMA metadata events to the topic.
-  license:
-    name: Apache 2.0
-    url: 'https://www.apache.org/licenses/LICENSE-2.0'
-servers:
-  production:
-    url: 'pulsar+ssl://prod.events.managed.async.api.legogroup.io:6651'
-    protocol: pulsar+ssl
-    description: Pulsar broker
-channels:
-  workspace:
-    x-eventarchetype: objectchanged
-    x-classification: green
-    x-datalakesubscription: true
-    publish:
-      bindings:
-        http:
-          $ref: '#/components/operationBindings/http'
-      message:
-        $ref: '#/components/messages/WorkspaceEventPayload'
-  api:
-    x-eventarchetype: objectchanged
-    x-classification: green
-    x-datalakesubscription: true
-    publish:
-      bindings:
-        http:
-          $ref: '#/components/operationBindings/http'
-      message:
-        $ref: '#/components/messages/APIEventPayload'
-components:
-  operationBindings:
-    http:
-      type: response
-  messages:
-    WorkspaceEventPayload:
-      schemaFormat: application/vnd.apache.avro;version=1.9.0,
-      summary: Metadata about a workspace that has been created, updated or deleted.
-      payload:
-        type: object
-        properties:
-          key:
-            type: string
-            description: Key of the message.
-          event:
-            type: string
-            description: Event type.
-          payload:
-            type: object
-            properties:
-              workspace:
-                type: string
-                description: Name of the workspace.
-              href:
-                type: string
-                description: Send an API request to this url for detailed data on the referenced workspace.
-                
-    APIEventPayload:
-      schemaFormat: application/schema+yaml;version=draft-07
-      summary: Metadata about an API that has been created, updated or deleted.
-      payload:
-        type: object
-        properties:
-          key:
-            type: string
-            description: Key of the message.
-          event:
-            type: string
-            description: Event type.
-          payload:
-            type: object
-            properties:
-              workspace:
-                type: string
-                description: Name of the workspace.
-              api:
-                type: string
-                description: Name of the API.
-              href:
-                type: string
-                description: Send an API request to this url for detailed data on the referenced API.
-";
-        var reader = new AsyncApiStringReader();
-        var doc = reader.Read(yaml, out var diagnostic);
-        Assert.AreEqual((doc.Channels["workspace"].Extensions["x-eventarchetype"] as AsyncApiString).Value,
-          "objectchanged");
-        Assert.AreEqual((doc.Channels["workspace"].Extensions["x-classification"] as AsyncApiString).Value, "green");
-        Assert.AreEqual((doc.Channels["workspace"].Extensions["x-datalakesubscription"] as AsyncApiBoolean).Value,
-          true);
-        var message = doc.Channels["workspace"].Publish.Message;
-        Assert.AreEqual(message.First().SchemaFormat, "application/schema+yaml;version=draft-07");
-        Assert.AreEqual(message.First().Summary, "Metadata about a workspace that has been created, updated or deleted.");
-        var payload = doc.Channels["workspace"].Publish.Message.First().Payload;
-        Assert.NotNull(payload);
-        Assert.AreEqual(typeof(AsyncApiSchema), payload.GetType());
-        var httpBinding = doc.Channels["workspace"].Publish.Bindings.First().Value as HttpOperationBinding;
-        Assert.AreEqual("response", httpBinding.Type);
-      }
 
       [Test]
       public void Read_WithBasicPlusContact_Deserializes()
       {
         var yaml = @"asyncapi: 2.3.0
 info:
-  title: AMMA
+  title: test
   version: 1.0.0
   contact:  
     name: API Support
@@ -146,7 +38,7 @@ channels:
       {
         var yaml = @"asyncapi: 2.3.0
 info:
-  title: AMMA
+  title: test
   version: 1.0.0
 channels:
   workspace:
@@ -155,10 +47,10 @@ channels:
         http:
           type: response
       message:
-        $ref: '#/components/messages/WorkspaceEventPayload'
+        $ref: '#/components/messages/testPayLoad'
 components:
   messages:
-    WorkspaceEventPayload:
+    testPayLoad:
       schemaFormat: application/schema+yaml;version=draft-07
       externalDocs: 
         description: Find more info here
@@ -455,7 +347,7 @@ components:
 ";
             var reader = new AsyncApiStringReader();
             var doc = reader.Read(yaml, out var diagnostic);
-            Assert.AreEqual("application/schema+yaml;version=draft-07", doc.Channels.First().Value.Publish.Message.First().SchemaFormat);
+            Assert.AreEqual("application/schema+yaml;version=draft-07", doc.Channels.First().Value.Publish.Message.First().SchemaFormat.GetDisplayName());
         }
 
         [Test]

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiMessage_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiMessage_Should.cs
@@ -31,7 +31,7 @@
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            message.SchemaFormat.Should().Be(SchemaFormat.AsyncApi);
+            message.SchemaFormat.Should().BeNull();
         }
 
         [Test]
@@ -56,7 +56,7 @@ schemaFormat: application/vnd.apache.avro;version=1.9.0";
         }
 
         [Test]
-        public void AsyncApiMessage_WithNoSchemaFormat_SerializesDefault()
+        public void AsyncApiMessage_WithNoSchemaFormat_DoesNotSerializeSchemaFormat()
         {
             // Arrange
             var expected =
@@ -65,8 +65,7 @@ schemaFormat: application/vnd.apache.avro;version=1.9.0";
     propertyA:
       type:
         - string
-        - 'null'
-schemaFormat: application/vnd.aai.asyncapi;version=2.5.0";
+        - 'null'";
 
             var message = new AsyncApiMessage();
             message.Payload = new AsyncApiSchema()
@@ -117,7 +116,7 @@ schemaFormat: application/vnd.aai.asyncapi+json;version=2.5.0";
                     {
                         "propertyA", new AsyncApiSchema()
                         {
-                            Type = new List<SchemaType> { SchemaType.String,SchemaType.Null },
+                            Type = new List<SchemaType> { SchemaType.String, SchemaType.Null },
                         }
                     },
                 },
@@ -223,6 +222,7 @@ traits:
                         },
                     },
                 },
+                SchemaFormat = SchemaFormat.AsyncApi,
                 Payload = new AsyncApiSchema()
                 {
                     Properties = new Dictionary<string, AsyncApiSchema>


### PR DESCRIPTION
SchemaFormat has a few MUSTs for schemaformat support.
This PR adds these.
This change is in line with changing the message payload type to SchemaObject

![image](https://user-images.githubusercontent.com/5294032/204257500-3fbad3d5-eded-45b4-bf06-1fb59f51077e.png)
