### PR TITLE
fix: payload schema reference resolution

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/AsyncApiReaderSettings.cs
+++ b/src/LEGO.AsyncAPI.Readers/AsyncApiReaderSettings.cs
@@ -16,7 +16,7 @@ namespace LEGO.AsyncAPI.Readers
         DoNotResolveReferences,
 
         /// <summary>
-        /// ResolveAllReferences effectively means load external references. Will be removed in v2. External references are never "resolved".
+        /// ResolveAllReferences, effectively inlining them.
         /// </summary>
         ResolveReferences,
     }
@@ -29,7 +29,6 @@ namespace LEGO.AsyncAPI.Readers
         /// <summary>
         /// Indicates how references in the source document should be handled.
         /// </summary>
-        /// <remarks>This setting will be going away in the next major version of this library.  Use GetEffective on model objects to get resolved references.</remarks>
         public ReferenceResolutionSetting ReferenceResolution { get; set; } =
             ReferenceResolutionSetting.ResolveReferences;
 

--- a/src/LEGO.AsyncAPI/Models/AsyncApiBindings.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiBindings.cs
@@ -28,7 +28,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiChannel.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiChannel.cs
@@ -59,7 +59,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiComponents.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiComponents.cs
@@ -97,7 +97,7 @@ namespace LEGO.AsyncAPI.Models
 
             // If references have been inlined we don't need the to render the components section
             // however if they have cycles, then we will need a component rendered
-            if (writer.GetSettings().ReferenceInline != ReferenceInlineSetting.DoNotInlineReferences)
+            if (writer.GetSettings().ReferenceInline == ReferenceInlineSetting.InlineReferences)
             {
                 var loops = writer.GetSettings().LoopDetector.Loops;
                 writer.WriteStartObject();

--- a/src/LEGO.AsyncAPI/Models/AsyncApiComponents.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiComponents.cs
@@ -97,7 +97,7 @@ namespace LEGO.AsyncAPI.Models
 
             // If references have been inlined we don't need the to render the components section
             // however if they have cycles, then we will need a component rendered
-            if (writer.GetSettings().ReferenceInline == ReferenceInlineSetting.InlineReferences)
+            if (writer.GetSettings().InlineReferences)
             {
                 var loops = writer.GetSettings().LoopDetector.Loops;
                 writer.WriteStartObject();

--- a/src/LEGO.AsyncAPI/Models/AsyncApiCorrelationId.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiCorrelationId.cs
@@ -38,7 +38,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
@@ -73,7 +73,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (writer.GetSettings().ReferenceInline == ReferenceInlineSetting.InlineReferences)
+            if (writer.GetSettings().InlineReferences)
             {
                 this.ResolveReferences();
             }

--- a/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
@@ -73,6 +73,11 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
+            if (writer.GetSettings().ReferenceInline == ReferenceInlineSetting.InlineReferences)
+            {
+                this.ResolveReferences();
+            }
+
             writer.WriteStartObject();
 
             // asyncApi
@@ -140,6 +145,11 @@ namespace LEGO.AsyncAPI.Models
             return resolver.Errors;
         }
 
+        internal T ResolveReference<T>(AsyncApiReference reference) where T : class, IAsyncApiReferenceable
+        {
+            return this.ResolveReference(reference) as T;
+        }
+
         public IAsyncApiReferenceable ResolveReference(AsyncApiReference reference)
         {
             if (reference == null)
@@ -151,7 +161,6 @@ namespace LEGO.AsyncAPI.Models
             {
                 throw new ArgumentException("Reference must have a type.");
             }
-
 
             if (this.Components == null)
             {
@@ -180,7 +189,6 @@ namespace LEGO.AsyncAPI.Models
                         return this.Components.OperationTraits[reference.Id];
                     case ReferenceType.MessageTrait:
                         return this.Components.MessageTraits[reference.Id];
-
                     case ReferenceType.ServerBinding:
                         return this.Components.ServerBindings[reference.Id];
                     case ReferenceType.ChannelBinding:

--- a/src/LEGO.AsyncAPI/Models/AsyncApiMessage.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiMessage.cs
@@ -106,7 +106,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiMessageTrait.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiMessageTrait.cs
@@ -96,7 +96,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiOperationTrait.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiOperationTrait.cs
@@ -61,7 +61,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiParameter.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiParameter.cs
@@ -43,7 +43,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiSchema.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiSchema.cs
@@ -396,7 +396,7 @@ namespace LEGO.AsyncAPI.Models
 
             if (this.Reference != null)
             {
-                if (settings.ReferenceInline != ReferenceInlineSetting.InlineReferences)
+                if (!settings.ShouldInlineReference(this.Reference))
                 {
                     this.Reference.SerializeV2(writer);
                     return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiSchema.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiSchema.cs
@@ -390,6 +390,8 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
+            var target = this;
+
             var settings = writer.GetSettings();
 
             if (this.Reference != null)
@@ -407,13 +409,27 @@ namespace LEGO.AsyncAPI.Models
                     this.Reference.SerializeV2(writer);
                     return;
                 }
+
+                target = this.GetReferenced(this.Reference.HostDocument);
             }
 
-            this.SerializeV2WithoutReference(writer);
+            target.SerializeV2WithoutReference(writer);
 
             if (this.Reference != null)
             {
                 settings.LoopDetector.PopLoop<AsyncApiSchema>();
+            }
+        }
+
+        public AsyncApiSchema GetReferenced(AsyncApiDocument document)
+        {
+            if (this.Reference != null && document != null)
+            {
+                return document.ResolveReference<AsyncApiSchema>(this.Reference);
+            }
+            else
+            {
+                return this;
             }
         }
     }

--- a/src/LEGO.AsyncAPI/Models/AsyncApiServer.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiServer.cs
@@ -69,7 +69,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/AsyncApiServerVariable.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiServerVariable.cs
@@ -46,7 +46,7 @@ namespace LEGO.AsyncAPI.Models
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Http/HttpMessageBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Http/HttpMessageBinding.cs
@@ -58,7 +58,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Http
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Http/HttpOperationBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Http/HttpOperationBinding.cs
@@ -59,7 +59,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Http
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaChannelBinding.cs
@@ -72,7 +72,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaMessageBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaMessageBinding.cs
@@ -80,7 +80,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaOperationBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaOperationBinding.cs
@@ -61,7 +61,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaServerBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Kafka/KafkaServerBinding.cs
@@ -60,7 +60,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Pulsar/PulsarChannelBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Pulsar/PulsarChannelBinding.cs
@@ -89,7 +89,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Pulsar
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/Pulsar/PulsarServerBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/Pulsar/PulsarServerBinding.cs
@@ -54,7 +54,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Pulsar
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Models/Bindings/WebSockets/WebSocketsChannelBinding.cs
+++ b/src/LEGO.AsyncAPI/Models/Bindings/WebSockets/WebSocketsChannelBinding.cs
@@ -59,7 +59,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.WebSockets
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            if (this.Reference != null && writer.GetSettings().ReferenceInline != ReferenceInlineSetting.InlineReferences)
+            if (this.Reference != null && !writer.GetSettings().ShouldInlineReference(this.Reference))
             {
                 this.Reference.SerializeV2(writer);
                 return;

--- a/src/LEGO.AsyncAPI/Services/AsyncApiReferenceResolver.cs
+++ b/src/LEGO.AsyncAPI/Services/AsyncApiReferenceResolver.cs
@@ -88,6 +88,7 @@ namespace LEGO.AsyncAPI.Services
         public override void Visit(AsyncApiMessage message)
         {
             this.ResolveObject(message.Headers, r => message.Headers = r);
+            this.ResolveObject(message.Payload, r => message.Payload = r);
             this.ResolveList(message.Traits);
             this.ResolveObject(message.CorrelationId, r => message.CorrelationId = r);
             var bindingDictionary = message.Bindings.Select(binding => binding.Value).ToDictionary(x => x.Type.GetDisplayName());

--- a/src/LEGO.AsyncAPI/Writers/AsyncApiWriterSettings.cs
+++ b/src/LEGO.AsyncAPI/Writers/AsyncApiWriterSettings.cs
@@ -3,6 +3,7 @@
 namespace LEGO.AsyncAPI.Writers
 {
     using LEGO.AsyncAPI.Models;
+    using System;
 
     public class AsyncApiWriterSettings
     {
@@ -13,6 +14,7 @@ namespace LEGO.AsyncAPI.Writers
         /// <summary>
         /// Gets or sets indicates how references in the source document should be handled.
         /// </summary>
+        [Obsolete]
         public ReferenceInlineSetting ReferenceInline
         {
             get
@@ -26,23 +28,23 @@ namespace LEGO.AsyncAPI.Writers
                 switch (this.referenceInline)
                 {
                     case ReferenceInlineSetting.DoNotInlineReferences:
-                        this.InLineReferences = false;
+                        this.InlineReferences = false;
                         break;
                     case ReferenceInlineSetting.InlineReferences:
-                        this.InLineReferences = true;
+                        this.InlineReferences = true;
                         break;
                 }
             }
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether indicates if local references should be rendered as an inline object
+        /// Gets or sets a value indicating whether indicates if local references should be rendered as an inline object.
         /// </summary>
-        public bool InLineReferences { get; set; } = false;
+        public bool InlineReferences { get; set; } = false;
 
         internal bool ShouldInlineReference(AsyncApiReference reference)
         {
-            return this.InLineReferences;
+            return this.InlineReferences;
         }
     }
 }

--- a/src/LEGO.AsyncAPI/Writers/AsyncApiWriterSettings.cs
+++ b/src/LEGO.AsyncAPI/Writers/AsyncApiWriterSettings.cs
@@ -14,7 +14,6 @@ namespace LEGO.AsyncAPI.Writers
         /// <summary>
         /// Gets or sets indicates how references in the source document should be handled.
         /// </summary>
-        [Obsolete]
         public ReferenceInlineSetting ReferenceInline
         {
             get

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
@@ -1,13 +1,159 @@
 ﻿using LEGO.AsyncAPI.Models;
 using LEGO.AsyncAPI.Readers;
+using LEGO.AsyncAPI.Writers;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 
 namespace LEGO.AsyncAPI.Tests.Models
 {
     public class AsyncApiSchema_Should
     {
+        private string NoInlinedReferences =>
+            @"asyncapi: '2.6.0'
+info:
+  title: Streetlights Kafka API
+  version: 1.0.0
+  description: The Smartylighting Streetlights API allows you to remotely manage the city lights.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+channels:
+  mychannel:
+    publish:
+      message:
+        payload:
+          type: object
+          required:
+            - testB
+          properties:
+            testC:
+              $ref: '#/components/schemas/testC'
+            testB:
+              $ref: '#/components/schemas/testB'
+components:
+  schemas:
+    testD:
+      type: string
+      format: uuid
+    testC:
+      type: object
+      properties:
+        testD:
+          $ref: '#/components/schemas/testD'
+    testB:
+      type: boolean
+      description: test";
+
+        private string InlinedReferences =>
+            @"asyncapi: '2.6.0'
+info:
+  title: Streetlights Kafka API
+  version: 1.0.0
+  description: The Smartylighting Streetlights API allows you to remotely manage the city lights.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+channels:
+  mychannel:
+    publish:
+      message:
+        payload:
+          type: object
+          required:
+            - testB
+          properties:
+            testC:
+              type: object
+              properties:
+                testD:
+                  type: string
+                  format: uuid
+            testB:
+              type: boolean
+              description: test
+components: { }";
+
+        [Theory]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Serialize_WithInliningOptions_ShouldInlineAccordingly(bool shouldInline)
+        {
+            // arrange
+            var asyncApiDocument = new AsyncApiDocumentBuilder()
+            .WithInfo(new AsyncApiInfo
+            {
+                Title = "Streetlights Kafka API",
+                Version = "1.0.0",
+                Description = "The Smartylighting Streetlights API allows you to remotely manage the city lights.",
+                License = new AsyncApiLicense
+                {
+                    Name = "Apache 2.0",
+                    Url = new Uri("https://www.apache.org/licenses/LICENSE-2.0"),
+                },
+            })
+            .WithChannel("mychannel", new AsyncApiChannel()
+            {
+                Publish = new AsyncApiOperation
+                {
+                    Message = new List<AsyncApiMessage>
+                    {
+                        new AsyncApiMessage
+                        {
+                            Payload = new AsyncApiSchema
+                            {
+                                Type = new List<SchemaType> { SchemaType.Object },
+                                Required = new HashSet<string> { "testB" },
+                                Properties = new Dictionary<string, AsyncApiSchema>
+                                {
+                                    { "testC", new AsyncApiSchema { Reference = new AsyncApiReference { Type = ReferenceType.Schema, Id = "testC" } } },
+                                    { "testB", new AsyncApiSchema { Reference = new AsyncApiReference { Type = ReferenceType.Schema, Id = "testB" } } },
+                                },
+                            },
+                        },
+                    },
+                },
+            })
+            .WithComponent("testD", new AsyncApiSchema() { Type = new List<SchemaType> { SchemaType.String }, Format = "uuid" })
+            .WithComponent("testC", new AsyncApiSchema()
+            {
+                Type = new List<SchemaType> { SchemaType.Object },
+                Properties = new Dictionary<string, AsyncApiSchema>
+                {
+                    { "testD", new AsyncApiSchema { Reference = new AsyncApiReference { Type = ReferenceType.Schema, Id = "testD" } } },
+                },
+            })
+            .WithComponent("testB", new AsyncApiSchema() { Description = "test", Type = new List<SchemaType> { SchemaType.Boolean } })
+            .Build();
+
+            var outputString = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new AsyncApiYamlWriter(outputString, new AsyncApiWriterSettings { InlineReferences = shouldInline });
+
+            // Act
+            asyncApiDocument.SerializeV2(writer);
+
+            var actual = outputString.ToString();
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+
+            string expected = string.Empty;
+
+            // Assert
+            if (shouldInline)
+            {
+                expected = this.InlinedReferences;
+            }
+            else
+            {
+                expected = this.NoInlinedReferences;
+            }
+
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+
+            Assert.AreEqual(actual, expected);
+        }
+
         [Test]
         public void SerializeV2_WithNullWriter_Throws()
         {


### PR DESCRIPTION
## About the PR
Dependency resolution is now enforced during writing depending on the writer settings.
Before you had to specifically call "ResolveReferences()".

This enables a slightly easier usecase, where you can create an object model of references, and still get a document out that matches the writer settings.

Payload has been added as a "Reference" type, as it should have been all along.

Payload sub references, now resolve correctly as well.

Using default setting (`ReferenceInlineSetting.DoNotInlineReferences`)
will yield the following output
``` yaml
channels:
  mychannel:
    publish:
      message:
        payload:
          type: object
          required:
            - testB
          properties:
            testC:
              $ref: '#/components/schemas/testC'
            testB:
              $ref: '#/components/schemas/testB'
components:
  schemas:
    testD:
      type: string
      format: uuid
    testC:
      type: object
      properties:
        testD:
          $ref: '#/components/schemas/testD'
    testB:
      type: boolean
      description: test
```

Where setting `ReferenceInlineSetting.InlineReferences`
Will now correctly resolve references from components
```yaml
channels:
  mychannel:
    publish:
      message:
        payload:
          type: object
          required:
            - testB
          properties:
            testC:
              type: object
              properties:
                testD:
                  type: string
                  format: uuid
            testB:
              type: boolean
              description: test
components: { }
```
### Changelog
- Added Payload as reference type
- Fixed Reference resolution for subreferences in payload
- Forced dependency resolution depending on Writer settings.


### Related Issues
Related to discussion #93 
