### PR TITLE
chore: add ability to throw AsyncApiExceptions during extension parsing

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/AsyncApiYamlDocumentReader.cs
+++ b/src/LEGO.AsyncAPI.Readers/AsyncApiYamlDocumentReader.cs
@@ -72,7 +72,7 @@ namespace LEGO.AsyncAPI.Readers
             return document;
         }
 
-        public async Task<ReadResult> ReadAsync(YamlDocument input)
+        public Task<ReadResult> ReadAsync(YamlDocument input)
         {
             var diagnostic = new AsyncApiDiagnostic();
             var context = new ParsingContext(diagnostic)
@@ -102,11 +102,11 @@ namespace LEGO.AsyncAPI.Readers
                 }
             }
 
-            return new ReadResult
+            return Task.FromResult(new ReadResult
             {
                 AsyncApiDocument = document,
                 AsyncApiDiagnostic = diagnostic,
-            };
+            });
         }
 
         private void ResolveReferences(AsyncApiDiagnostic diagnostic, AsyncApiDocument document)

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiDeserializer.cs
@@ -165,15 +165,21 @@ namespace LEGO.AsyncAPI.Readers
 
         private static IAsyncApiExtension LoadExtension(string name, ParseNode node)
         {
-            if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
+            try
             {
-                return parser(
-                    AsyncApiAnyConverter.GetSpecificAsyncApiAny(node.CreateAny()));
+                if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
+                {
+                    return parser(
+                        AsyncApiAnyConverter.GetSpecificAsyncApiAny(node.CreateAny()));
+                }
             }
-            else
+            catch (AsyncApiException ex)
             {
-                return AsyncApiAnyConverter.GetSpecificAsyncApiAny(node.CreateAny());
+                ex.Pointer = node.Context.GetLocation();
+                node.Context.Diagnostic.Errors.Add(new AsyncApiError(ex));
             }
+
+            return AsyncApiAnyConverter.GetSpecificAsyncApiAny(node.CreateAny());
         }
 
         private static string LoadString(ParseNode node)

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
@@ -11,7 +11,7 @@ namespace LEGO.AsyncAPI.Readers
 
     internal static partial class AsyncApiV2Deserializer
     {
-        private static readonly FixedFieldMap<AsyncApiSchema> schemaFixedFields = new()
+        private static readonly FixedFieldMap<AsyncApiSchema> schemaFixedFields = new ()
         {
             {
                 "title", (a, n) => { a.Title = n.GetScalarValue(); }

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -17,6 +17,86 @@
 
     public class AsyncApiDocumentV2Tests
     {
+
+        [Test]
+        public void test()
+        {
+            var input = @"asyncapi: 2.0.0
+info:
+  title: Sites
+  version: 1.0.0
+  description: Responsible for emitting the site on/off
+  x-application-id: APP-02042
+  x-audience: component-internal
+channels:
+  site-events:
+    subscribe:
+      message:
+        payload:
+          properties:
+            data:
+              '$ref': '#/components/schemas/DtosSiteUpdatedEvent'
+              description: The actual payload of the event
+            datacontenttype:
+              description: Always application/json
+              type: string
+              example: application/json
+            id:
+              description: The unique ID of the event
+              type: string
+              example: 3489d4b1e21badf3665dae24c6526169
+            source:
+              description: The source of the event
+              type: string
+              example: LEGO.OmnichannelFulfilment.DeliveryOrchestration/Sites
+            specversion:
+              description: The CloudEvents schema version used
+              type: string
+              example: 1.0
+            time:
+              description: The time the event was published
+              format: date-time
+              type: string
+              example: 2022-10-13T11:57:36.268054757Z
+            type:
+              description: The type of the event
+              type: string
+              example: siteUpdatedV1
+            traceparent:
+              description: The value to propagate context information that enables distributed tracing scenarios
+              type: string
+              example: 3489d4b1e21badf3665dae24c6526169
+          type: object
+        summary: Subscriber message
+        description: All data used for turning on or off a site request
+    x-classification: green
+    x-datalakesubscription: false
+    x-eventarchetype: objectchanged
+    x-eventdurability: persistent
+components:
+  schemas:
+    DtosSiteUpdatedEvent:
+      properties:
+        enabled:
+          description: The Enabled shows the current status of the site
+          type: boolean
+          examples:
+          - false
+        siteId:
+          description: The SiteCode related to the site that is being turn on or off
+          type: string
+          examples:
+          - 489
+        reason:
+          description: The reason the site is being turned on or off
+          type: string
+          examples:
+          - Workers striking require us to temporary close the site.
+      type: object
+";
+            var serialized = new AsyncApiStringReader().Read(input, out var diag);
+
+        }
         [Test]
         public void AsyncApiDocument_WithStreetLightsExample_SerializesAndDeserializes()
         {
@@ -1122,6 +1202,934 @@ components:
 
             // Assert
             Assert.AreEqual(actual, expected);
+        }
+
+        [Test]
+        public void tesT()
+        {
+            var spec = @"asyncapi: '2.6.0'
+defaultContentType: 'application/json'
+info:
+  title: '{TITLE}'
+  version: '{VERSION}'
+  x-audience: company-internal
+  x-application-id: APP-01575
+  x-eventdeduplication: false
+  contact:
+    name: Team Deadlock
+    email: Deadlock@o365.corp.LEGO.com
+    url: https://legogroup.atlassian.net/wiki/spaces/TD/pages/37143022928/Consent+Service
+  description: |
+    Emits events related to consent changes for both LEGO Account users and anonymous users.
+    This includes both parental consents and cookie consents.
+channels:
+  userconsents.objectchanged:
+    x-eventarchetype: objectchanged
+    x-eventdurability: persistent
+    x-classification: yellow
+    description: |
+      A topic for events regarding changes to user consents. The event archetype is set to 'objectchanged' which will enable tombstoning and compaction. 
+    subscribe:
+      operationId: UserConsentsObjectChanged
+      message:
+        oneOf:
+          - $ref: '#/components/messages/UserConsentsObjectCreated'
+          - $ref: '#/components/messages/UserConsentsObjectChanged'
+          - $ref: '#/components/messages/UserConsentsObjectDeleted'
+  userconsents.fieldchanged:
+    x-eventarchetype: fieldchanged
+    x-eventdurability: persistent
+    x-classification: yellow
+    description: |
+      A topic for deleted user consents events. The event archetype is set to 'fieldchanged' in order to enforce a 28 days retention policy. 
+    subscribe:
+      operationId: UserConsentsFieldChanged
+      message:
+        oneOf:
+          - $ref: '#/components/messages/UserConsentFieldCreated'
+          - $ref: '#/components/messages/UserConsentFieldChanged'
+          - $ref: '#/components/messages/UserConsentFieldDeleted'
+  anonymousconsent.fieldchange:
+    x-eventarchetype: fieldchanged
+    x-eventdurability: persistent
+    x-classification: green
+    description: |
+      A topic for events regarding changes to anonymous consents. The event archetype is set to 'fieldchanged' in order to enforce a 28 days retention policy.
+    subscribe:
+      operationId: AnonymousConsentsFieldChanged
+      message:
+        oneOf:
+          - $ref: '#/components/messages/AnonymousConsentFieldChange'
+  experiences.events:
+    x-eventarchetype: objectchanged
+    x-eventdurability: persistent
+    x-classification: yellow
+    description: |
+      A topic for experience events. The event archetype is set to 'objectchanged' in order to store event forever.
+    subscribe:
+      operationId: ExperiencesChanged
+      message:
+        oneOf:
+          - $ref: '#/components/messages/ExperienceCreated'
+          - $ref: '#/components/messages/ExperienceDeleted'
+          - $ref: '#/components/messages/ExperienceUpdated'
+          - $ref: '#/components/messages/ExperienceClientAdded'
+          - $ref: '#/components/messages/ExperienceClientRemoved'
+          - $ref: '#/components/messages/ExperienceConsentOptionAdded'
+          - $ref: '#/components/messages/ExperienceConsentOptionRemoved'
+components:
+  schemas:
+    EnvelopeBase:
+      type: object
+      properties:
+        type: 
+          type: string
+          description: The type of event.
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header         
+        data:
+          type: object
+
+    EnvelopeOfUserConsentsObjectCreated:
+      allOf:
+        - $ref: '#/components/schemas/EnvelopeBase'
+        - type: object
+          properties:
+            type: 
+              enum: [UserConsentsObjectCreated]
+            data:
+              $ref: '#/components/schemas/UserConsentsObjectCreated'
+
+    EnvelopeOfUserConsentsObjectChanged:
+      allOf:
+        - $ref: '#/components/schemas/EnvelopeBase'
+        - type: object
+          properties:
+            type: 
+              enum: [UserConsentsObjectChanged]
+            data:
+              $ref: '#/components/schemas/UserConsentsObjectChanged'
+    EnvelopeOfUserConsentsObjectDeleted:
+      allOf:
+        - $ref: '#/components/schemas/EnvelopeBase'
+        - type: object
+          properties:
+            type: 
+              enum: [UserConsentsObjectDeleted]
+            data:
+              $ref: '#/components/schemas/UserConsentsObjectDeleted'
+    UserConsentsObjectCreated:
+      type: object
+      required:
+        - changeType
+        - changeTime
+        - userId
+        - consents
+      properties:
+        changeType:
+          type: string
+          enum: ['created']
+          description: The change type of the event.
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples: 
+            - 2023-01-18T13:19:08.132084
+        userId:
+          type: string
+          format: guid
+          description: The ID of the user. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consents:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserConsent'
+    UserConsentsObjectChanged:
+      type: object
+      required:
+        - changeType
+        - changeTime
+        - userId
+        - consents
+      properties:
+        changeType:
+          type: string
+          enum: ['updated']
+          description: The change type of the event.
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples: 
+            - 2023-01-18T13:19:08.132084
+        userId:
+          type: string
+          format: guid
+          description: The ID of the user. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consents:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserConsent'
+    UserConsentsObjectDeleted:
+      type: object
+      required:
+        - changeType
+        - changeTime
+        - userId
+      properties:
+        changeType:
+          type: string
+          enum: ['deleted']
+          description: The change type of the event.
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples: 
+            - 2023-01-18T13:19:08.132084
+        userId:
+          type: string
+          format: guid
+          description: The ID of the user. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+    UserConsent:
+      type: object
+      required:
+        - consentId
+        - consenterUserId
+        - consentState
+        - culture
+      properties:
+        consentId:
+          type: string
+          format: uri
+          description: The consent option URI
+          examples: 
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+        consenterUserId:
+          type: string
+          format: guid
+          description: The ID of the user giving the consent. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentState:
+          type: string
+          description: The state of the consent for the given consent option
+          enum: ['granted','denied','undecided']
+        culture:
+          type: string
+          minLength: 5
+          maxLength: 5
+          description: The culture where the consent was changed.
+          examples: 
+            - da-DK
+            - en-US
+            - en-GB
+        submissionSource:
+          type: string
+          description: The method used by the user to submit the cookies
+          enum: ['prebannerAcceptAll', 'prebannerRejectAll', 'savePrefButton', 'cloned' ]    
+        
+    EnvelopeOfUserConsentFieldCreatedEvent:
+      allOf:
+        - $ref: '#/components/schemas/EnvelopeBase'
+        - type: object
+          properties:
+            type: 
+              enum: [UserConsentFieldCreatedEvent]
+            data:
+              $ref: '#/components/schemas/UserConsentFieldCreatedEvent'
+    EnvelopeOfUserConsentFieldChangedEvent:
+      allOf:
+        - $ref: '#/components/schemas/EnvelopeBase'
+        - type: object
+          properties:
+            type: 
+              enum: [UserConsentFieldChangedEvent]
+            data:
+              $ref: '#/components/schemas/UserConsentFieldChangedEvent'
+    EnvelopeOfUserConsentFieldDeletedEvent:
+      allOf:
+        - $ref: '#/components/schemas/EnvelopeBase'
+        - type: object
+          properties:
+            type: 
+              enum: [UserConsentFieldDeletedEvent]
+            data:
+              $ref: '#/components/schemas/UserConsentFieldDeletedEvent'
+
+    UserConsentFieldCreatedEvent:
+      type: object
+      required:
+        - changeType
+        - changeTime
+        - userId
+        - consentId
+        - consenterUserId
+        - consentState
+        - culture
+      properties:
+        changeType:
+          type: string
+          enum: ['created','updated','deleted']
+          description: The change type of the event.
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples: 
+            - 2023-01-18T13:19:08.132084
+        userId:
+          type: string
+          format: guid
+          description: The ID of the user. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentId:
+          type: string
+          format: uri
+          description: The consent option URI
+          examples: 
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+        consenterUserId:
+          type: string
+          format: guid
+          description: The ID of the user giving the consent. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentState:
+          type: string
+          description: The state of the consent for the given consent option
+          enum: ['granted','denied','undecided']
+        culture:
+          type: string
+          minLength: 5
+          maxLength: 5
+          description: The culture where the consent was changed.
+          examples: 
+            - da-DK
+            - en-US
+            - en-GB
+        submissionSource:
+          type: string
+          description: The method used by the user to submit the cookies
+          enum: ['prebannerAcceptAll', 'prebannerRejectAll', 'savePrefButton', 'cloned' ]  
+
+    UserConsentFieldChangedEvent:
+      type: object
+      required:
+        - changeType
+        - changeTime
+        - userId
+        - consentId
+        - consenterUserId
+        - consentState
+        - culture
+      properties:
+        changeType:
+          type: string
+          enum: ['created','updated','deleted']
+          description: The change type of the event.
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples: 
+            - 2023-01-18T13:19:08.132084
+        userId:
+          type: string
+          format: guid
+          description: The ID of the user. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentId:
+          type: string
+          format: uri
+          description: The consent option URI
+          examples: 
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+        consenterUserId:
+          type: string
+          format: guid
+          description: The ID of the user giving the consent. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentState:
+          type: string
+          description: The state of the consent for the given consent option
+          enum: ['granted','denied','undecided']
+        culture:
+          type: string
+          minLength: 5
+          maxLength: 5
+          description: The culture where the consent was changed.
+          examples: 
+            - da-DK
+            - en-US
+            - en-GB
+        submissionSource:
+          type: string
+          description: The method used by the user to submit the cookies
+          enum: ['prebannerAcceptAll', 'prebannerRejectAll', 'savePrefButton', 'cloned' ]  
+
+    UserConsentFieldDeletedEvent:
+      type: object
+      required:
+        - changeType
+        - changeTime
+        - userId
+        - consentId
+      properties:
+        changeType:
+          type: string
+          enum: ['deleted']
+          description: The change type of the event.
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples: 
+            - 2023-01-18T13:19:08.132084
+        userId:
+          type: string
+          format: guid
+          description: The ID of the user. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentId:
+          type: string
+          format: uri
+          description: The consent option URI
+          examples: 
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+
+    EnvelopeOfAnonymousConsentFieldChangeEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'anonymousconsents.fieldchanged'.
+          enum: [anonymousconsents.fieldchanged]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/AnonymousConsentFieldChangeEvent'
+    EnvelopeOfExperienceCreatedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.created'.
+          enum: [experience.created]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceCreatedEvent'
+    EnvelopeOfExperienceDeletedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.deleted'.
+          enum: [experience.deleted]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceDeletedEvent'
+    EnvelopeOfExperienceUpdatedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.updated'.
+          enum: [experience.updated]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceUpdatedEvent'
+    EnvelopeOfExperienceClientAddedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.client.added'.
+          enum: [experience.client.added]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceClientAddedEvent'
+    EnvelopeOfExperienceClientRemovedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.client.removed'.
+          enum: [experience.client.removed]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceClientRemovedEvent'
+    EnvelopeOfExperienceConsentOptionAddedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.consentoption.added'.
+          enum: [experience.consentoption.added]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceConsentOptionAddedEvent'
+    EnvelopeOfExperienceConsentOptionRemovedEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of event. Will always have the value 'experience.consentoption.removed'.
+          enum: [experience.consentoption.removed]
+        correlationId:
+          type: string
+          description: |
+            The correlation ID as defined in https://github.com/LEGO/api-matters/blob/main/docs/practices/sync-apis/restful/readme.md#124-correlation-id-header
+        data:
+          $ref: '#/components/schemas/ExperienceConsentOptionRemovedEvent'
+    
+    AnonymousConsentFieldChangeEvent:
+      type: object
+      required:
+        - ChangeType
+        - ChangeTime
+        - AnonymousUserId
+        - ConsentId
+        - ConsentState
+        - Culture
+      properties:
+        changeType:
+          type: string
+          description: The change type
+          examples:
+            - Created
+            - Updated
+            - Deleted
+        changeTime:
+          type: string
+          format: date-time
+          description: 'The date and time of when the user consent was changed. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        anonymousUserId:
+          type: string
+          format: guid
+          description: The anonymous user ID. The GUID is 32 digits separated by hyphens and is not considered to be PII.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+        consentId:
+          type: string
+          description: The consent option URI
+          examples:
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+        consentState:
+          type: string
+          description: The state of the consent for the given consent id
+          examples:
+            - granted
+            - denied
+            - undecided
+        culture:
+          type: string
+          minLength: 5
+          maxLength: 5
+          description: The culture where the consent was changed.
+          examples:
+            - da-DK
+            - en-US
+            - en-GB
+    ExperienceCreatedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+        - name
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        name:
+          type: string
+          description: name of experience
+          minLength: 1
+          maxLength: 100
+          examples:
+            - LEGO Webshop
+    ExperienceUpdatedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+        - name
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        name:
+          type: string
+          description: name of experience
+          minLength: 1
+          maxLength: 100
+          examples:
+            - LEGO Webshop
+    ExperienceDeletedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+    ExperienceClientAddedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+        - clientId
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        clientId:
+          type: string
+          format: guid
+          description: Identity client id.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+    ExperienceClientRemovedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+        - clientId
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        clientId:
+          type: string
+          format: guid
+          description: Identity client id.
+          minLength: 36
+          maxLength: 36
+          examples:
+            - 95b2cb5f-d551-4106-805c-9b800b1a0133
+    ExperienceConsentOptionAddedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+        - consentOption
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        clientId:
+          type: string
+          description: The consent option URI
+          examples:
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+    ExperienceConsentOptionRemovedEvent:
+      type: object
+      required:
+        - experienceId
+        - occurredOnTimestamp
+        - consentOption
+      properties:
+        experienceId:
+          type: string
+          description: The experience id.
+          minLength: 1
+          maxLength: 40
+          examples:
+            - lego.com
+        occurredOnTimestamp:
+          type: string
+          format: date-time
+          description: 'The date and time of when experience was created. The format is in RFC 3339.'
+          examples:
+            - 2023-01-18T13:19:08.132084
+        clientId:
+          type: string
+          description: The consent option URI
+          examples:
+            - self-consent://global/analytic-cookies
+            - self-consent://global/necessary-cookies
+            - self-consent://global/lego-marketing-cookies
+  messages:
+    UserConsentsObjectCreated:
+      messageId: UserConsentsObjectCreated
+      name: User consents object created
+      title: The object state of consents for a user
+      description: An event emitted whenever a user's consent is created.
+      tags:
+        - name: user
+        - name: consents
+        - name: created
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfUserConsentsObjectCreated'
+    UserConsentsObjectChanged:
+      messageId: UserConsentsObjectChanged
+      name: User consents object changed
+      title: The object state of consents for a user
+      description: An event emitted whenever a user's consent is changed.
+      tags:
+        - name: user
+        - name: consents
+        - name: changed
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfUserConsentsObjectChanged'
+    UserConsentsObjectDeleted:
+      messageId: UserConsentsObjectDeleted
+      name: User consents object deleted
+      title: The object state of consents for a user
+      description: An event emitted whenever a user's consent is deleted.
+      tags:
+        - name: user
+        - name: consents
+        - name: deleted
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfUserConsentsObjectDeleted'
+    UserConsentFieldCreated:
+      messageId: UserConsentFieldCreated
+      name: User consent field created
+      title: The change of 1 specific consent being created
+      description: An event emitted whenever a user's consent is created.
+      tags:
+        - name: user
+        - name: consents
+        - name: created
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfUserConsentFieldCreatedEvent'
+    UserConsentFieldChanged:
+      messageId: UserConsentFieldChanged
+      name: User consent field changed
+      title: The change of 1 specific consent being changed
+      description: An event emitted whenever a user's consent is changed.
+      tags:
+        - name: user
+        - name: consents
+        - name: changed
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfUserConsentFieldChangedEvent'
+    UserConsentFieldDeleted:
+      messageId: UserConsentFieldDeleted
+      name: User consent field deleted
+      title: The change of 1 specific consent being deleted
+      description: An event emitted whenever a user's consent is deleted.
+      tags:
+        - name: user
+        - name: consents
+        - name: deleted
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfUserConsentFieldDeletedEvent'
+    AnonymousConsentFieldChange:
+      messageId: AnonymousConsentFieldChange
+      name: Anonymous consent field change
+      title: Anonymous consent field change event
+      description: An event emitted whenever an anonymous consent is changed (added, updated or removed).
+      tags:
+        - name: anonymous
+        - name: consents
+        - name: deleted
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfAnonymousConsentFieldChangeEvent'
+    ExperienceCreated:
+      messageId: ExperienceCreated
+      name: Experience created
+      title: Experience created event
+      description: An event emitted whenever an experience is created.
+      tags:
+        - name: experience
+        - name: created
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceCreatedEvent'
+    ExperienceDeleted:
+      messageId: ExperienceDeleted
+      name: Experience deleted
+      title: Experience deleted event
+      description: An event emitted whenever an experience is deleted.
+      tags:
+        - name: experience
+        - name: deleted
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceDeletedEvent'
+    ExperienceUpdated:
+      messageId: ExperienceUpdated
+      name: Experience updated
+      title: Experience updated event
+      description: An event emitted whenever an experience is updated.
+      tags:
+        - name: experience
+        - name: updated
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceUpdatedEvent'
+    ExperienceClientAdded:
+      messageId: ExperienceClientAdded
+      name: Experience client added
+      title: Experience client added event
+      description: An event emitted whenever a client is added to experience.
+      tags:
+        - name: experience
+        - name: updated
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceClientAddedEvent'
+    ExperienceClientRemoved:
+      messageId: ExperienceClientRemoved
+      name: Experience client removed
+      title: Experience client removed event
+      description: An event emitted whenever a client is removed from experience.
+      tags:
+        - name: experience
+        - name: updated
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceClientRemovedEvent'
+    ExperienceConsentOptionAdded:
+      messageId: ExperienceConsentOptionAdded
+      name: Experience consent option added
+      title: Experience consent option added event
+      description: An event emitted whenever an consent option is added to experience.
+      tags:
+        - name: experience
+        - name: updated
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceConsentOptionAddedEvent'
+    ExperienceConsentOptionRemoved:
+      messageId: ExperienceConsentOptionRemoved
+      name: Experience consent option removed
+      title: Experience consent option removed event
+      description: An event emitted whenever an consent option is removed from experience.
+      tags:
+        - name: experience
+        - name: updated
+      payload:
+        $ref: '#/components/schemas/EnvelopeOfExperienceConsentOptionRemovedEvent'
+";
+
+            var reader = new AsyncApiStringReader();
+            var deserialized = reader.Read(spec, out var diagnostic);
         }
 
         [Test]


### PR DESCRIPTION
## About the PR
To better enable extension validation, any thrown `AsyncApiExceptions` during ExtensionParsing, will be pushed to the diagnostics Errors list.
