### PR TITLE
test: Added a new property to the custom binding tests

### DIFF
--- a/test/LEGO.AsyncAPI.Tests/Bindings/CustomBinding_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/CustomBinding_Should.cs
@@ -54,7 +54,7 @@ namespace LEGO.AsyncAPI.Tests.Bindings
             { "custom", (a, n) => { a.Custom = n.GetScalarValue(); } },
             { "any", (a, n) => { a.Any = n.CreateAny(); } },
             { "nestedConfiguration", (a, n) => { a.NestedConfiguration = n.ParseMapWithExtensions(NestedConfiguration.FixedFieldMap); } },
-            { "myList", (a, n) => { a.MyList = n.CreateList((x) => x.GetScalarValue()); } }
+            { "myList", (a, n) => { a.MyList = n.CreateSimpleList((x) => x.GetScalarValue()); } }
         };
 
         public override void SerializeProperties(IAsyncApiWriter writer)
@@ -161,14 +161,16 @@ channels:
           - item03
         x-myextension: someValue";
 
+            // Act
             var settings = new AsyncApiReaderSettings();
             settings.Bindings.Add(new MyBinding());
 
             var reader = new AsyncApiStringReader(settings);
 
-            var result = reader.Read(input, out var diagnostic);
+            var asyncApiDocument = reader.Read(input, out var diagnostic);
             
-            Console.WriteLine(JsonSerializer.Serialize(diagnostic.Errors));
+            // Assert
+            Assert.NotNull(asyncApiDocument);
             Assert.False(diagnostic.Errors.Any());
         }
     }


### PR DESCRIPTION
## About the PR
I've created this PR just to ask a question using a new unit test. 

I am trying to read an AsyncAPI specification file which has a custom binding. Also the binding has a `List<string>` property and I am getting an error while reading that. 

To replicate the scenario I added a new unit test `CustomBinding_WhenInSpec_SerializesDeserializes`. My goal is to read that custom binding but I am getting an error while reading the `myList` property. You can see the error from the diagnostic below;

Error: `[{"Message":"Expected map.","Pointer":"#/channels/TestChannel/bindings/myList"}]`

