### PR TITLE
fix: async schema deserializer "additionalProperties" not deserializing JsonSchema correctly

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
@@ -125,7 +125,7 @@ namespace LEGO.AsyncAPI.Readers
             {
                 "additionalProperties", (a, n) =>
                 {
-                    if (n.GetBooleanValueOrDefault(null) == false)
+                    if (n is ValueNode && n.GetBooleanValueOrDefault(null) == false)
                     {
                         a.AdditionalProperties = new NoAdditionalProperties();
                     }
@@ -170,6 +170,9 @@ namespace LEGO.AsyncAPI.Readers
             },
             {
                 "deprecated", (a, n) => { a.Deprecated = bool.Parse(n.GetScalarValue()); }
+            },
+            {
+                "nullable", (a, n) => { a.Nullable = n.GetBooleanValue(); }
             },
         };
 

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
@@ -407,15 +407,15 @@ components: { }";
           ""type"": ""string"",
           ""minLength"": 2
         }
-      }
-    },
-    ""additionalProperties"": {
-      ""properties"": {
-        ""Property8"": {
-          ""type"": [
-            ""null"",
-            ""string""
-          ]
+      },
+      ""additionalProperties"": {
+        ""properties"": {
+          ""Property8"": {
+            ""type"": [
+              ""null"",
+              ""string""
+            ]
+          }
         }
       }
     }

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright (c) The LEGO Group. All rights reserved.
 
+using System.Linq;
+using LEGO.AsyncAPI.Bindings;
+using LEGO.AsyncAPI.Readers;
+
 namespace LEGO.AsyncAPI.Tests.Models
 {
     using System;
@@ -87,6 +91,16 @@ namespace LEGO.AsyncAPI.Tests.Models
                         {
                             Type = SchemaType.String,
                             MinLength = 2,
+                        },
+                    },
+                    AdditionalProperties = new AsyncApiSchema
+                    {
+                        Properties = new Dictionary<string, AsyncApiSchema>
+                        {
+                            ["Property8"] = new AsyncApiSchema
+                            {
+                                Type = SchemaType.String | SchemaType.Null,
+                            },
                         },
                     },
                 },
@@ -394,6 +408,16 @@ components: { }";
           ""minLength"": 2
         }
       }
+    },
+    ""additionalProperties"": {
+      ""properties"": {
+        ""Property8"": {
+          ""type"": [
+            ""null"",
+            ""string""
+          ]
+        }
+      }
     }
   },
   ""nullable"": true,
@@ -409,6 +433,66 @@ components: { }";
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
+        }
+
+        [Test]
+        public void Deserialize_WithAdditionalProperties_Works()
+        {
+            // Arrange
+            var json = @"{
+  ""title"": ""title1"",
+  ""properties"": {
+    ""property1"": {
+      ""properties"": {
+        ""property2"": {
+          ""type"": ""integer""
+        },
+        ""property3"": {
+          ""type"": ""string"",
+          ""maxLength"": 15
+        }
+      },
+      ""additionalProperties"": false
+    },
+    ""property4"": {
+      ""properties"": {
+        ""property5"": {
+          ""properties"": {
+            ""property6"": {
+              ""type"": ""boolean""
+            }
+          }
+        },
+        ""property7"": {
+          ""type"": ""string"",
+          ""minLength"": 2
+        }
+      },
+      ""additionalProperties"": {
+        ""properties"": {
+          ""Property8"": {
+            ""type"": [
+              ""null"",
+              ""string""
+            ]
+          }
+        }
+      }
+    }
+  },
+  ""nullable"": true,
+  ""externalDocs"": {
+    ""url"": ""http://example.com/externalDocs""
+  }
+}";
+            var expected = AdvancedSchemaObject;
+
+            // Act
+            var actual = new AsyncApiStringReader().ReadFragment<AsyncApiSchema>(json, AsyncApiVersion.AsyncApi2_0, out var _diagnostics);
+
+            // Assert
+            actual.Should().BeEquivalentTo(expected);
+            _diagnostics.Errors.Should().BeEmpty();
         }
 
         [Test]


### PR DESCRIPTION
## About the PR
Additional properties field of the async spec were experiencing a bug. Having the "additionalProperties" present caused the library to throw an Error as the MapNode didn't implement GetBooleanValueOrDefault and the code thus defaulted to the abstract ParseNode implementation which throw an exception.

This PR tries to cast the node to a ValueNode before calling GetBooleanValueOrDefault else the already existing behaviour.

Unit test to accommodate the change.

### Changelog
- Add: Fixed bug causing additionalProperties to cause an Error.
- Remove: Removed bug causing additionalProperties to cause an Error.
