### PR TITLE
fix: parse const keyword in a schema object

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
@@ -102,6 +102,9 @@ namespace LEGO.AsyncAPI.Readers
                 "enum", (a, n) => { a.Enum = n.CreateListOfAny(); }
             },
             {
+                "const", (a, n) => { a.Const = n.CreateAny(); }
+            },
+            {
                 "examples", (a, n) => { a.Examples = n.CreateListOfAny(); }
             },
             {

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
@@ -104,6 +104,10 @@ namespace LEGO.AsyncAPI.Tests.Models
                         },
                     },
                 },
+                ["property9"] = new AsyncApiSchema
+                {
+                    Const = new AsyncApiString("aSpecialConstant"),
+                },
             },
             Nullable = true,
             ExternalDocs = new AsyncApiExternalDocumentation
@@ -418,6 +422,9 @@ components: { }";
           }
         }
       }
+    },
+    ""property9"": {
+      ""const"": ""aSpecialConstant""
     }
   },
   ""nullable"": true,
@@ -478,6 +485,9 @@ components: { }";
           }
         }
       }
+    },
+    ""property9"": {
+      ""const"": ""aSpecialConstant""
     }
   },
   ""nullable"": true,
@@ -596,7 +606,7 @@ components: { }";
                     { "testD", new AsyncApiSchema { Reference = new AsyncApiReference { Type = ReferenceType.Schema, Id = "testD" } } },
                 },
             })
-            .WithComponent("testB", new AsyncApiSchema() { Description = "test", Type = SchemaType.Boolean  })
+            .WithComponent("testB", new AsyncApiSchema() { Description = "test", Type = SchemaType.Boolean })
             .Build();
 
             var outputString = new StringWriter(CultureInfo.InvariantCulture);


### PR DESCRIPTION
## About the PR
Accept the `const` keyword for the `schema` object. See full definition [here](https://www.asyncapi.com/docs/reference/specification/v2.3.0#schema).

### Changelog
- Add: const to `AsyncApiSchemaDeserializer`
- Add: some tests
