### PR TITLE
feat(bindings): add high throughput fifo properties

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Sqs/Queue.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/Queue.cs
@@ -2,12 +2,9 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
 {
     using System;
     using System.Collections.Generic;
-    using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Writers;
-    using Extensions;
-    using LEGO.AsyncAPI.Readers;
-    using LEGO.AsyncAPI.Readers.ParseNodes;
+    using LEGO.AsyncAPI.Attributes;
 
     public class Queue : IAsyncApiExtensible
     {
@@ -20,6 +17,16 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
         /// Is this a FIFO queue?
         /// </summary>
         public bool FifoQueue { get; set; }
+
+        /// <summary>
+        /// Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).
+        /// </summary>
+        public DeduplicationScope? DeduplicationScope { get; set; }
+
+        /// <summary>
+        /// Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.
+        /// </summary>
+       public FifoThroughputLimit? FifoThroughputLimit { get; set; }
 
         /// <summary>
         /// The number of seconds to delay before a message sent to the queue can be received. used to create a delay queue.
@@ -68,6 +75,8 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
             writer.WriteStartObject();
             writer.WriteRequiredProperty("name", this.Name);
             writer.WriteOptionalProperty("fifoQueue", this.FifoQueue);
+            writer.WriteOptionalProperty("deduplicationScope", this.DeduplicationScope?.GetDisplayName());
+            writer.WriteOptionalProperty("fifoThroughputLimit", this.FifoThroughputLimit?.GetDisplayName());
             writer.WriteOptionalProperty("deliveryDelay", this.DeliveryDelay);
             writer.WriteOptionalProperty("visibilityTimeout", this.VisibilityTimeout);
             writer.WriteOptionalProperty("receiveMessageWaitTime", this.ReceiveMessageWaitTime);
@@ -78,5 +87,17 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
             writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }
+    }
+
+    public enum DeduplicationScope
+    {
+        [Display("queue")] Queue,
+        [Display("messageGroup")] MessageGroup,
+    }
+
+    public enum FifoThroughputLimit
+    {
+        [Display("perQueue")] PerQueue,
+        [Display("perMessageGroupId")] PerMessageGroupId,
     }
 }

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/SqsChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/SqsChannelBinding.cs
@@ -31,6 +31,8 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
         {
             { "name", (a, n) => { a.Name = n.GetScalarValue(); } },
             { "fifoQueue", (a, n) => { a.FifoQueue = n.GetBooleanValue(); } },
+            { "deduplicationScope", (a, n) => { a.DeduplicationScope = n.GetScalarValue().GetEnumFromDisplayName<DeduplicationScope>(); } },
+            { "fifoThroughputLimit", (a, n) => { a.FifoThroughputLimit = n.GetScalarValue().GetEnumFromDisplayName<FifoThroughputLimit>(); } },
             { "deliveryDelay", (a, n) => { a.DeliveryDelay = n.GetIntegerValue(); } },
             { "visibilityTimeout", (a, n) => { a.VisibilityTimeout = n.GetIntegerValue(); } },
             { "receiveMessageWaitTime", (a, n) => { a.ReceiveMessageWaitTime = n.GetIntegerValue(); } },

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/SqsOperationBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/SqsOperationBinding.cs
@@ -23,6 +23,8 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
         {
             { "name", (a, n) => { a.Name = n.GetScalarValue(); } },
             { "fifoQueue", (a, n) => { a.FifoQueue = n.GetBooleanValue(); } },
+            { "deduplicationScope", (a, n) => { a.DeduplicationScope = n.GetScalarValue().GetEnumFromDisplayName<DeduplicationScope>(); } },
+            { "fifoThroughputLimit", (a, n) => { a.FifoThroughputLimit = n.GetScalarValue().GetEnumFromDisplayName<FifoThroughputLimit>(); } },
             { "deliveryDelay", (a, n) => { a.DeliveryDelay = n.GetIntegerValue(); } },
             { "visibilityTimeout", (a, n) => { a.VisibilityTimeout = n.GetIntegerValue(); } },
             { "receiveMessageWaitTime", (a, n) => { a.ReceiveMessageWaitTime = n.GetIntegerValue(); } },

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sqs/SqsBindings_should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sqs/SqsBindings_should.cs
@@ -23,6 +23,8 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
     queue:
       name: myQueue
       fifoQueue: true
+      deduplicationScope: messageGroup
+      fifoThroughputLimit: perMessageGroupId
       deliveryDelay: 30
       visibilityTimeout: 60
       receiveMessageWaitTime: 0
@@ -78,6 +80,8 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
                 {
                     Name = "myQueue",
                     FifoQueue = true,
+                    DeduplicationScope = DeduplicationScope.MessageGroup,
+                    FifoThroughputLimit = FifoThroughputLimit.PerMessageGroupId,
                     DeliveryDelay = 30,
                     VisibilityTimeout = 60,
                     ReceiveMessageWaitTime = 0,
@@ -234,6 +238,8 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
     queues:
       - name: myQueue
         fifoQueue: true
+        deduplicationScope: queue
+        fifoThroughputLimit: perQueue
         deliveryDelay: 30
         visibilityTimeout: 60
         receiveMessageWaitTime: 0
@@ -292,6 +298,8 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
                     {
                         Name = "myQueue",
                         FifoQueue = true,
+                        DeduplicationScope = DeduplicationScope.Queue,
+                        FifoThroughputLimit = FifoThroughputLimit.PerQueue,
                         DeliveryDelay = 30,
                         VisibilityTimeout = 60,
                         ReceiveMessageWaitTime = 0,

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sqs/SqsBindings_should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sqs/SqsBindings_should.cs
@@ -237,9 +237,6 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
   sqs:
     queues:
       - name: myQueue
-        fifoQueue: true
-        deduplicationScope: queue
-        fifoThroughputLimit: perQueue
         deliveryDelay: 30
         visibilityTimeout: 60
         receiveMessageWaitTime: 0
@@ -297,9 +294,9 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
                     new Queue()
                     {
                         Name = "myQueue",
-                        FifoQueue = true,
-                        DeduplicationScope = DeduplicationScope.Queue,
-                        FifoThroughputLimit = FifoThroughputLimit.PerQueue,
+                        FifoQueue = false,
+                        DeduplicationScope = null,
+                        FifoThroughputLimit = null,
                         DeliveryDelay = 30,
                         VisibilityTimeout = 60,
                         ReceiveMessageWaitTime = 0,


### PR DESCRIPTION
## About the PR

This PR adds the missing properties required to enable high throughput on a FIFO queue. The two properties are deduplicationScope and fifoThroughputLimit. As outlined in the AWS documentation - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/high-throughput-fifo.html#enable-high-throughput-fifo.

I have raised a PR on the AsyncAPI binding repo which has been approved and is awaiting merge - https://github.com/asyncapi/bindings/pull/216.

### Changelog
- Add: `deduplicationScope` FIFO queue binding property to both channel and operation binding.
- Add: `fifoThroughputLimit` FIFO queue binding property to both channel and operation binding.
