### PR TITLE
feat: add support for vendor-specific topic configuration

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -39,7 +39,7 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
             { "topic", (a, n) => { a.Topic = n.GetScalarValue(); } },
             { "partitions", (a, n) => { a.Partitions = n.GetIntegerValue(); } },
-            { "topicConfiguration", (a, n) => { a.TopicConfiguration = n.ParseMap(kafkaChannelTopicConfigurationObjectFixedFields); } },
+            { "topicConfiguration", (a, n) => { a.TopicConfiguration = n.ParseMapWithExtensions(kafkaChannelTopicConfigurationObjectFixedFields); } },
             { "replicas", (a, n) => { a.Replicas = n.GetIntegerValue(); } },
         };
 
@@ -50,7 +50,6 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
             { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetIntegerValue(); } },
             { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetIntegerValue(); } },
             { "max.message.bytes", (a, n) => { a.MaxMessageBytes = n.GetIntegerValue(); } },
-            { "custom.configs", (a, n) => { a.CustomConfigs = n.CreateSimpleMap(s => s.GetScalarValue()); } },
         };
 
         /// <summary>

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -50,6 +50,7 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
             { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetIntegerValue(); } },
             { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetIntegerValue(); } },
             { "max.message.bytes", (a, n) => { a.MaxMessageBytes = n.GetIntegerValue(); } },
+            { "custom.configs", (a, n) => { a.CustomConfigs = n.CreateSimpleMap(s => s.GetScalarValue()); } },
         };
 
         /// <summary>

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -4,7 +4,6 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
 {
     using System;
     using LEGO.AsyncAPI.Models;
-    using LEGO.AsyncAPI.Models.Bindings.Kafka;
     using LEGO.AsyncAPI.Readers.ParseNodes;
     using LEGO.AsyncAPI.Writers;
 
@@ -47,9 +46,9 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         private static FixedFieldMap<TopicConfigurationObject> kafkaChannelTopicConfigurationObjectFixedFields = new ()
         {
             { "cleanup.policy", (a, n) => { a.CleanupPolicy = n.CreateSimpleList(s => s.GetScalarValue()); } },
-            { "retention.ms", (a, n) => { a.RetentionMiliseconds = n.GetIntegerValue(); } },
+            { "retention.ms", (a, n) => { a.RetentionMilliseconds = n.GetIntegerValue(); } },
             { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetIntegerValue(); } },
-            { "delete.retention.ms", (a, n) => { a.DeleteRetentionMiliseconds = n.GetIntegerValue(); } },
+            { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetIntegerValue(); } },
             { "max.message.bytes", (a, n) => { a.MaxMessageBytes = n.GetIntegerValue(); } },
         };
 

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
@@ -9,7 +9,7 @@ using LEGO.AsyncAPI.Writers;
 namespace LEGO.AsyncAPI.Bindings.Kafka
 {
 
-    public class TopicConfigurationObject : IAsyncApiElement
+    public class TopicConfigurationObject : IAsyncApiExtensible
     {
         /// <summary>
         /// The cleanup.policy configuration option.
@@ -37,9 +37,9 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         public int? MaxMessageBytes { get; set; }
         
         /// <summary>
-        /// The custom.configs properties configuration option.
+        /// Extensions can be used to handle the configurations that are not covered by AsyncAPI bindings.
         /// </summary>
-        public Dictionary<string, string>? CustomConfigs { get; set; }
+        public IDictionary<string, IAsyncApiExtension> Extensions { get; set; } = new Dictionary<string, IAsyncApiExtension>();
 
         public void Serialize(IAsyncApiWriter writer)
         {
@@ -54,7 +54,7 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
             writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionBytes, this.RetentionBytes);
             writer.WriteOptionalProperty<int>(AsyncApiConstants.DeleteRetentionMilliseconds, this.DeleteRetentionMilliseconds);
             writer.WriteOptionalProperty<int>(AsyncApiConstants.MaxMessageBytes, this.MaxMessageBytes);
-            writer.WriteOptionalMap(AsyncApiConstants.CustomConfigs, this.CustomConfigs, (w, t) => w.WriteValue(t));
+            writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }
     }

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
@@ -35,6 +35,11 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         /// The max.message.bytes configuration option.
         /// </summary>
         public int? MaxMessageBytes { get; set; }
+        
+        /// <summary>
+        /// The custom.configs properties configuration option.
+        /// </summary>
+        public Dictionary<string, string>? CustomConfigs { get; set; }
 
         public void Serialize(IAsyncApiWriter writer)
         {
@@ -49,6 +54,7 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
             writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionBytes, this.RetentionBytes);
             writer.WriteOptionalProperty<int>(AsyncApiConstants.DeleteRetentionMilliseconds, this.DeleteRetentionMilliseconds);
             writer.WriteOptionalProperty<int>(AsyncApiConstants.MaxMessageBytes, this.MaxMessageBytes);
+            writer.WriteOptionalMap(AsyncApiConstants.CustomConfigs, this.CustomConfigs, (w, t) => w.WriteValue(t));
             writer.WriteEndObject();
         }
     }

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) The LEGO Group. All rights reserved.
 
-namespace LEGO.AsyncAPI.Models.Bindings.Kafka
+using System;
+using System.Collections.Generic;
+using LEGO.AsyncAPI.Models;
+using LEGO.AsyncAPI.Models.Interfaces;
+using LEGO.AsyncAPI.Writers;
+
+namespace LEGO.AsyncAPI.Bindings.Kafka
 {
-    using System;
-    using System.Collections.Generic;
-    using LEGO.AsyncAPI.Models.Interfaces;
-    using LEGO.AsyncAPI.Writers;
 
     public class TopicConfigurationObject : IAsyncApiElement
     {
@@ -17,7 +19,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
         /// <summary>
         /// The retention.ms configuration option.
         /// </summary>
-        public int? RetentionMiliseconds { get; set; }
+        public int? RetentionMilliseconds { get; set; }
 
         /// <summary>
         /// The retention.bytes configuration option.
@@ -27,7 +29,7 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
         /// <summary>
         /// The delete.retention.ms configuration option.
         /// </summary>
-        public int? DeleteRetentionMiliseconds { get; set; }
+        public int? DeleteRetentionMilliseconds { get; set; }
 
         /// <summary>
         /// The max.message.bytes configuration option.
@@ -43,9 +45,9 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
 
             writer.WriteStartObject();
             writer.WriteOptionalCollection(AsyncApiConstants.CleanupPolicy, this.CleanupPolicy, (w, s) => w.WriteValue(s));
-            writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionMiliseconds, this.RetentionMiliseconds);
+            writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionMilliseconds, this.RetentionMilliseconds);
             writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionBytes, this.RetentionBytes);
-            writer.WriteOptionalProperty<int>(AsyncApiConstants.DeleteRetentionMiliseconds, this.DeleteRetentionMiliseconds);
+            writer.WriteOptionalProperty<int>(AsyncApiConstants.DeleteRetentionMilliseconds, this.DeleteRetentionMilliseconds);
             writer.WriteOptionalProperty<int>(AsyncApiConstants.MaxMessageBytes, this.MaxMessageBytes);
             writer.WriteEndObject();
         }

--- a/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
@@ -136,6 +136,7 @@ namespace LEGO.AsyncAPI.Models
         public const string RetentionBytes = "retention.bytes";
         public const string DeleteRetentionMilliseconds = "delete.retention.ms";
         public const string MaxMessageBytes = "max.message.bytes";
+        public const string CustomConfigs = "custom.configs";
         public const string TopicConfiguration = "topicConfiguration";
         public const string GeoReplication = "geo-replication";
         public const string AdditionalItems = "additionalItems";

--- a/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
@@ -132,9 +132,9 @@ namespace LEGO.AsyncAPI.Models
         public const string ServerVariables = "serverVariables";
         public const string MessageId = "messageId";
         public const string CleanupPolicy = "cleanup.policy";
-        public const string RetentionMiliseconds = "retention.ms";
+        public const string RetentionMilliseconds = "retention.ms";
         public const string RetentionBytes = "retention.bytes";
-        public const string DeleteRetentionMiliseconds = "delete.retention.ms";
+        public const string DeleteRetentionMilliseconds = "delete.retention.ms";
         public const string MaxMessageBytes = "max.message.bytes";
         public const string TopicConfiguration = "topicConfiguration";
         public const string GeoReplication = "geo-replication";

--- a/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
@@ -136,7 +136,6 @@ namespace LEGO.AsyncAPI.Models
         public const string RetentionBytes = "retention.bytes";
         public const string DeleteRetentionMilliseconds = "delete.retention.ms";
         public const string MaxMessageBytes = "max.message.bytes";
-        public const string CustomConfigs = "custom.configs";
         public const string TopicConfiguration = "topicConfiguration";
         public const string GeoReplication = "geo-replication";
         public const string AdditionalItems = "additionalItems";

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
@@ -2,14 +2,13 @@
 
 namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
 {
+    using System.Collections.Generic;
     using FluentAssertions;
     using LEGO.AsyncAPI.Bindings;
     using LEGO.AsyncAPI.Bindings.Kafka;
     using LEGO.AsyncAPI.Models;
-    using LEGO.AsyncAPI.Models.Bindings.Kafka;
     using LEGO.AsyncAPI.Readers;
     using NUnit.Framework;
-    using System.Collections.Generic;
 
     internal class KafkaBindings_Should
     {
@@ -41,9 +40,9 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
                 TopicConfiguration = new TopicConfigurationObject()
                 {
                     CleanupPolicy = new List<string> { "delete", "compact" },
-                    RetentionMiliseconds = 1,
+                    RetentionMilliseconds = 1,
                     RetentionBytes = 2,
-                    DeleteRetentionMiliseconds = 3,
+                    DeleteRetentionMilliseconds = 3,
                     MaxMessageBytes = 4,
                 },
             });

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
@@ -29,7 +29,10 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
       retention.ms: 1
       retention.bytes: 2
       delete.retention.ms: 3
-      max.message.bytes: 4";
+      max.message.bytes: 4
+      custom.configs:
+        key.schema.validation: 'true'
+        key.subject.name.strategy: TopicNameStrategy";
 
             var channel = new AsyncApiChannel();
             channel.Bindings.Add(new KafkaChannelBinding
@@ -44,7 +47,13 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
                     RetentionBytes = 2,
                     DeleteRetentionMilliseconds = 3,
                     MaxMessageBytes = 4,
+                    CustomConfigs = new Dictionary<string, string>
+                    {
+                        { "key.schema.validation", "true" },
+                        { "key.subject.name.strategy", "TopicNameStrategy" }
+                    },
                 },
+                
             });
 
             // Act

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) The LEGO Group. All rights reserved.
 
+using LEGO.AsyncAPI.Models.Any;
+using LEGO.AsyncAPI.Models.Interfaces;
+
 namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
 {
     using System.Collections.Generic;
@@ -30,9 +33,8 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
       retention.bytes: 2
       delete.retention.ms: 3
       max.message.bytes: 4
-      custom.configs:
-        key.schema.validation: 'true'
-        key.subject.name.strategy: TopicNameStrategy";
+      x-key.schema.validation: true
+      x-key.subject.name.strategy: TopicNameStrategy";
 
             var channel = new AsyncApiChannel();
             channel.Bindings.Add(new KafkaChannelBinding
@@ -47,13 +49,12 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
                     RetentionBytes = 2,
                     DeleteRetentionMilliseconds = 3,
                     MaxMessageBytes = 4,
-                    CustomConfigs = new Dictionary<string, string>
+                    Extensions = new Dictionary<string, IAsyncApiExtension>
                     {
-                        { "key.schema.validation", "true" },
-                        { "key.subject.name.strategy", "TopicNameStrategy" }
+                        { "x-key.schema.validation", new AsyncApiBoolean(true) },
+                        { "x-key.subject.name.strategy", new AsyncApiString("TopicNameStrategy") },
                     },
                 },
-                
             });
 
             // Act


### PR DESCRIPTION
## About the PR
Currently, only 5 topic configuration properties are supported by the asyncapi kafka binding (json schema [here](https://github.com/asyncapi/spec-json-schemas/blob/master/bindings/kafka/0.4.0/channel.json#L28)).

These properties are;
- cleanup.policy
- retention.ms
- retention.bytes
- delete.retention.ms
- max.message.bytes

But in some cases, there is a need to specify vendor-specific topic configurations (e.g. [confluent-topic-configs](https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html)). Currently, there is no way to set custom configs for the **topicConfigurationObject**. 

I introduced `custom.configs` property to solve that issue. This is an additional property for the **topicConfigurationObject** and additional properties will be enabled in the asyncapi binding repo as well  (please see the related [PR](https://github.com/asyncapi/bindings/pull/228)) so there are no impediments for us to use that additional property.

I hope the description was clear and please let me know if you have any questions/suggestions.
