### PR TITLE
fix: added missing mapping for ordering

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Sns/SnsChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/SnsChannelBinding.cs
@@ -37,6 +37,7 @@ namespace LEGO.AsyncAPI.Bindings.Sns
         {
             { "name", (a, n) => { a.Name = n.GetScalarValue(); } },
             { "type", (a, n) => { a.Ordering = n.ParseMapWithExtensions(this.orderingFixedFields); } },
+            { "ordering", (a, n) => { a.Ordering = n.ParseMapWithExtensions(this.orderingFixedFields); } },
             { "policy", (a, n) => { a.Policy = n.ParseMapWithExtensions(this.policyFixedFields); } },
             { "tags", (a, n) => { a.Tags = n.CreateSimpleMap(s => s.GetScalarValue()); } },
         };

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
@@ -1,17 +1,16 @@
-using System;
+using System.Linq;
 using LEGO.AsyncAPI.Models.Any;
 using LEGO.AsyncAPI.Models.Interfaces;
-using BindingsCollection = LEGO.AsyncAPI.Bindings.BindingsCollection;
 
 namespace LEGO.AsyncAPI.Tests.Bindings.Sns
 {
-    using NUnit.Framework;
     using System.Collections.Generic;
     using FluentAssertions;
     using LEGO.AsyncAPI.Bindings;
     using LEGO.AsyncAPI.Bindings.Sns;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Readers;
+    using NUnit.Framework;
 
     internal class SnsBindings_Should
     {
@@ -145,8 +144,9 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
 
             // Assert
             Assert.AreEqual(actual, expected);
-            binding.Should().BeEquivalentTo(channel);
-
+            
+            var expectedSnsBinding = (SnsChannelBinding)channel.Bindings.Values.First();
+            expectedSnsBinding.Should().BeEquivalentTo((SnsChannelBinding)binding.Bindings.Values.First());
         }
         
         [Test]
@@ -389,7 +389,9 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
             // Assert
             Assert.AreEqual(actual, expected);
             binding.Should().BeEquivalentTo(operation);
-
+            
+            var expectedSnsBinding = (SnsOperationBinding)operation.Bindings.Values.First();
+            expectedSnsBinding.Should().BeEquivalentTo((SnsOperationBinding)binding.Bindings.Values.First());
         }
     }
 }

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
@@ -388,7 +388,6 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
 
             // Assert
             Assert.AreEqual(actual, expected);
-            binding.Should().BeEquivalentTo(operation);
             
             var expectedSnsBinding = (SnsOperationBinding)operation.Bindings.Values.First();
             expectedSnsBinding.Should().BeEquivalentTo((SnsOperationBinding)binding.Bindings.Values.First());


### PR DESCRIPTION
## About the PR
sns ordering property is not getting parsed due to the missing mapping.

### Changelog
- Fix: Added missing mapping for sns ordering property

