### PR TITLE
fix: updated topic configuration data types

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -47,9 +47,9 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         private static FixedFieldMap<TopicConfigurationObject> kafkaChannelTopicConfigurationObjectFixedFields = new ()
         {
             { "cleanup.policy", (a, n) => { a.CleanupPolicy = n.CreateSimpleList(s => s.GetScalarValue()); } },
-            { "retention.ms", (a, n) => { a.RetentionMiliseconds = n.GetIntegerValue(); } },
+            { "retention.ms", (a, n) => { a.RetentionMilliseconds = n.GetIntegerValue(); } },
             { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetIntegerValue(); } },
-            { "delete.retention.ms", (a, n) => { a.DeleteRetentionMiliseconds = n.GetIntegerValue(); } },
+            { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetIntegerValue(); } },
             { "max.message.bytes", (a, n) => { a.MaxMessageBytes = n.GetIntegerValue(); } },
             { "confluent.key.schema.validation", (a, n) => { a.ConfluentKeySchemaValidation = n.GetBooleanValue(); } },
             { "confluent.key.subject.name.strategy", (a, n) => { a.ConfluentKeySubjectName = n.GetScalarValue(); } },

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
@@ -17,17 +17,17 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
         /// <summary>
         /// The retention.ms configuration option.
         /// </summary>
-        public int? RetentionMiliseconds { get; set; }
+        public long? RetentionMilliseconds { get; set; }
 
         /// <summary>
         /// The retention.bytes configuration option.
         /// </summary>
-        public int? RetentionBytes { get; set; }
+        public long? RetentionBytes { get; set; }
 
         /// <summary>
         /// The delete.retention.ms configuration option.
         /// </summary>
-        public int? DeleteRetentionMiliseconds { get; set; }
+        public long? DeleteRetentionMilliseconds { get; set; }
 
         /// <summary>
         /// The max.message.bytes configuration option.
@@ -63,10 +63,10 @@ namespace LEGO.AsyncAPI.Models.Bindings.Kafka
 
             writer.WriteStartObject();
             writer.WriteOptionalCollection(AsyncApiConstants.CleanupPolicy, this.CleanupPolicy, (w, s) => w.WriteValue(s));
-            writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionMiliseconds, this.RetentionMiliseconds);
-            writer.WriteOptionalProperty<int>(AsyncApiConstants.RetentionBytes, this.RetentionBytes);
-            writer.WriteOptionalProperty<int>(AsyncApiConstants.DeleteRetentionMiliseconds, this.DeleteRetentionMiliseconds);
-            writer.WriteOptionalProperty<int>(AsyncApiConstants.MaxMessageBytes, this.MaxMessageBytes);
+            writer.WriteOptionalProperty(AsyncApiConstants.RetentionMilliseconds, this.RetentionMilliseconds);
+            writer.WriteOptionalProperty(AsyncApiConstants.RetentionBytes, this.RetentionBytes);
+            writer.WriteOptionalProperty(AsyncApiConstants.DeleteRetentionMilliseconds, this.DeleteRetentionMilliseconds);
+            writer.WriteOptionalProperty(AsyncApiConstants.MaxMessageBytes, this.MaxMessageBytes);
             writer.WriteOptionalProperty<bool>(AsyncApiConstants.ConfluentKeySchemaValidation, this.ConfluentKeySchemaValidation);
             writer.WriteOptionalProperty(AsyncApiConstants.ConfluentKeySubjectName, this.ConfluentKeySubjectName);
             writer.WriteOptionalProperty<bool>(AsyncApiConstants.ConfluentValueSchemaValidation, this.ConfluentValueSchemaValidation);

--- a/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiConstants.cs
@@ -132,9 +132,9 @@ namespace LEGO.AsyncAPI.Models
         public const string ServerVariables = "serverVariables";
         public const string MessageId = "messageId";
         public const string CleanupPolicy = "cleanup.policy";
-        public const string RetentionMiliseconds = "retention.ms";
+        public const string RetentionMilliseconds = "retention.ms";
         public const string RetentionBytes = "retention.bytes";
-        public const string DeleteRetentionMiliseconds = "delete.retention.ms";
+        public const string DeleteRetentionMilliseconds = "delete.retention.ms";
         public const string MaxMessageBytes = "max.message.bytes";
         public const string ConfluentKeySchemaValidation = "confluent.key.schema.validation";
         public const string ConfluentKeySubjectName = "confluent.key.subject.name.strategy";

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
@@ -27,7 +27,7 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
       cleanup.policy:
         - delete
         - compact
-      retention.ms: 1
+      retention.ms: 2592000000
       retention.bytes: 2
       delete.retention.ms: 3
       max.message.bytes: 4
@@ -45,9 +45,9 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
                 TopicConfiguration = new TopicConfigurationObject()
                 {
                     CleanupPolicy = new List<string> { "delete", "compact" },
-                    RetentionMiliseconds = 1,
+                    RetentionMilliseconds = 2592000000,
                     RetentionBytes = 2,
-                    DeleteRetentionMiliseconds = 3,
+                    DeleteRetentionMilliseconds = 3,
                     MaxMessageBytes = 4,
                     ConfluentKeySchemaValidation = true,
                     ConfluentKeySubjectName = "TopicNameStrategy",


### PR DESCRIPTION
## About the PR
<!-- Description of the PR should go here  -->
The following properties need to be updated as `long`:
- **retention.ms**

- **retention.bytes**

- **delete.retention.ms**

If you need further details about the configs you can check this documentation page: https://kafka.apache.org/documentation/#topicconfigs_retention.bytes

### Changelog
- Updated data types from **integer** to **long**

### Note
I have also created a PR in the **asyncapi/bindings** repo here: https://github.com/asyncapi/bindings/pull/242
