### PR TITLE
fix: retention values should use GetLongValue

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -47,7 +47,7 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         private static FixedFieldMap<TopicConfigurationObject> kafkaChannelTopicConfigurationObjectFixedFields = new ()
         {
             { "cleanup.policy", (a, n) => { a.CleanupPolicy = n.CreateSimpleList(s => s.GetScalarValue()); } },
-            { "retention.ms", (a, n) => { a.RetentionMilliseconds = n.GetIntegerValue(); } },
+            { "retention.ms", (a, n) => { a.RetentionMilliseconds = n.GetLongValue(); } },
             { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetIntegerValue(); } },
             { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetIntegerValue(); } },
             { "max.message.bytes", (a, n) => { a.MaxMessageBytes = n.GetIntegerValue(); } },

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -48,8 +48,8 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         {
             { "cleanup.policy", (a, n) => { a.CleanupPolicy = n.CreateSimpleList(s => s.GetScalarValue()); } },
             { "retention.ms", (a, n) => { a.RetentionMilliseconds = n.GetLongValue(); } },
-            { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetIntegerValue(); } },
-            { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetIntegerValue(); } },
+            { "retention.bytes", (a, n) => { a.RetentionBytes = n.GetLongValue(); } },
+            { "delete.retention.ms", (a, n) => { a.DeleteRetentionMilliseconds = n.GetLongValue(); } },
             { "max.message.bytes", (a, n) => { a.MaxMessageBytes = n.GetIntegerValue(); } },
             { "confluent.key.schema.validation", (a, n) => { a.ConfluentKeySchemaValidation = n.GetBooleanValue(); } },
             { "confluent.key.subject.name.strategy", (a, n) => { a.ConfluentKeySubjectName = n.GetScalarValue(); } },

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
@@ -27,7 +27,7 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
       cleanup.policy:
         - delete
         - compact
-      retention.ms: 2592000000
+      retention.ms: 15552000000
       retention.bytes: 2
       delete.retention.ms: 3
       max.message.bytes: 4
@@ -45,7 +45,7 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
                 TopicConfiguration = new TopicConfigurationObject()
                 {
                     CleanupPolicy = new List<string> { "delete", "compact" },
-                    RetentionMilliseconds = 2592000000,
+                    RetentionMilliseconds = 15552000000,
                     RetentionBytes = 2,
                     DeleteRetentionMilliseconds = 3,
                     MaxMessageBytes = 4,


### PR DESCRIPTION
## About the PR
retention.ms was recently converted to long, however, I noticed in my project that a long value was being processed as null. It seems there was an integer method leftover on the KafkaChannelBinding class. This PR fixes this issue for all retention values.

### Changelog
- Add: Long value for testing retention.ms in the Kafka bindings test
- Replace: Replaced GetIntegerValue with GetLongValue for all long retention values in the KafkaChannelBinding
