### PR TITLE
feat: improve AsyncApiAny api surface.

### DIFF
--- a/src/LEGO.AsyncAPI/Models/Any/AsyncAPIArray.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncAPIArray.cs
@@ -2,11 +2,13 @@
 
 namespace LEGO.AsyncAPI.Models
 {
+    using System;
     using System.Collections.ObjectModel;
     using System.Text.Json.Nodes;
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Writers;
 
+    [Obsolete("Please use AsyncApiAny instead")]
     public class AsyncApiArray : Collection<AsyncApiAny>, IAsyncApiExtension, IAsyncApiElement
     {
 

--- a/src/LEGO.AsyncAPI/Models/Any/AsyncAPIObject.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncAPIObject.cs
@@ -2,6 +2,7 @@
 
 namespace LEGO.AsyncAPI.Models
 {
+    using System;
     using System.Collections.Generic;
     using System.Text.Json.Nodes;
     using LEGO.AsyncAPI.Models.Interfaces;
@@ -10,6 +11,7 @@ namespace LEGO.AsyncAPI.Models
     /// <summary>
     /// AsyncApi object.
     /// </summary>
+    [Obsolete("Please use AsyncApiAny instead")]
     public class AsyncApiObject : Dictionary<string, AsyncApiAny>, IAsyncApiExtension, IAsyncApiElement
     {
 

--- a/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
@@ -2,6 +2,11 @@
 
 namespace LEGO.AsyncAPI.Models
 {
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+    using System.Text.Json;
     using System.Text.Json.Nodes;
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Writers;
@@ -13,6 +18,11 @@ namespace LEGO.AsyncAPI.Models
     /// <seealso cref="LEGO.AsyncAPI.Models.Interfaces.IAsyncApiExtension" />
     public class AsyncApiAny : IAsyncApiElement, IAsyncApiExtension
     {
+        private JsonSerializerOptions options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
         private JsonNode node;
 
         /// <summary>
@@ -20,6 +30,64 @@ namespace LEGO.AsyncAPI.Models
         /// </summary>
         /// <param name="node">The node.</param>
         public AsyncApiAny(JsonNode node)
+        {
+            this.node = node;
+        }
+
+        public AsyncApiAny(object obj)
+        {
+            this.node = JsonNode.Parse(JsonSerializer.Serialize(obj, this.options));
+        }
+
+        public AsyncApiAny(Dictionary<string, AsyncApiAny> dictionary)
+        {
+            var jsonObject = new JsonObject();
+            foreach (var kvp in dictionary)
+            {
+                jsonObject.Add(kvp.Key, kvp.Value.node);
+            }
+
+            this.node = jsonObject;
+        }
+
+        public AsyncApiAny(List<object> list)
+        {
+            var jsonArray = new JsonArray();
+            foreach (var item in list)
+            {
+                string jsonString = JsonSerializer.Serialize(item, this.options);
+                jsonArray.Add(JsonNode.Parse(jsonString));
+            }
+
+            this.node = jsonArray;
+        }
+
+        public AsyncApiAny(Dictionary<string, object> dictionary)
+        {
+            var jsonObject = new JsonObject();
+            foreach (var kvp in dictionary)
+            {
+                string jsonString = JsonSerializer.Serialize(kvp.Value, this.options);
+                jsonObject.Add(kvp.Key, JsonNode.Parse(jsonString));
+            }
+
+            this.node = jsonObject;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// </summary>
+        /// <param name="node">The node.</param>
+        public AsyncApiAny(JsonArray node)
+        {
+            this.node = node;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// </summary>
+        /// <param name="node">The node.</param>
+        public AsyncApiAny(JsonObject node)
         {
             this.node = node;
         }
@@ -34,7 +102,22 @@ namespace LEGO.AsyncAPI.Models
 
         public T GetValue<T>()
         {
-            return this.node.GetValue<T>();
+            return JsonSerializer.Deserialize<T>(this.node.ToJsonString());
+        }
+
+        public bool TryGetValue<T>(out T value)
+        {
+            try
+            {
+
+                value = this.GetValue<T>();
+                return true;
+            }
+            catch (System.Exception)
+            {
+                value = default(T);
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
@@ -64,7 +64,7 @@ namespace LEGO.AsyncAPI.Models
         /// <typeparam name="T">T.</typeparam>
         /// <param name="extension">The extension.</param>
         /// <returns><see cref="{T}"/>.</returns>
-        public static T FromExtension<T>(IAsyncApiExtension extension)
+        public static T FromExtensionOrDefault<T>(IAsyncApiExtension extension)
         {
             if (extension is AsyncApiAny any)
             {
@@ -122,7 +122,6 @@ namespace LEGO.AsyncAPI.Models
         {
             try
             {
-
                 value = this.GetValue<T>();
                 return true;
             }

--- a/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
@@ -92,6 +92,11 @@ namespace LEGO.AsyncAPI.Models
         /// <returns><see cref="{T}" />.</returns>
         public T GetValue<T>()
         {
+            if (this.node is JsonValue)
+            {
+                return this.node.GetValue<T>();
+            }
+
             return JsonSerializer.Deserialize<T>(this.node.ToJsonString());
         }
 

--- a/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
@@ -2,10 +2,7 @@
 
 namespace LEGO.AsyncAPI.Models
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Linq;
     using System.Text.Json;
     using System.Text.Json.Nodes;
     using LEGO.AsyncAPI.Models.Interfaces;
@@ -26,7 +23,7 @@ namespace LEGO.AsyncAPI.Models
         private JsonNode node;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// Initializes a new instance of the <see cref="AsyncApiAny" /> class.
         /// </summary>
         /// <param name="node">The node.</param>
         public AsyncApiAny(JsonNode node)
@@ -34,11 +31,19 @@ namespace LEGO.AsyncAPI.Models
             this.node = node;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// </summary>
+        /// <param name="obj">The object.</param>
         public AsyncApiAny(object obj)
         {
             this.node = JsonNode.Parse(JsonSerializer.Serialize(obj, this.options));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// </summary>
+        /// <param name="dictionary">The dictionary.</param>
         public AsyncApiAny(Dictionary<string, AsyncApiAny> dictionary)
         {
             var jsonObject = new JsonObject();
@@ -50,6 +55,10 @@ namespace LEGO.AsyncAPI.Models
             this.node = jsonObject;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// </summary>
+        /// <param name="list">The list.</param>
         public AsyncApiAny(List<object> list)
         {
             var jsonArray = new JsonArray();
@@ -62,6 +71,10 @@ namespace LEGO.AsyncAPI.Models
             this.node = jsonArray;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
+        /// </summary>
+        /// <param name="dictionary">The dictionary.</param>
         public AsyncApiAny(Dictionary<string, object> dictionary)
         {
             var jsonObject = new JsonObject();
@@ -73,6 +86,7 @@ namespace LEGO.AsyncAPI.Models
 
             this.node = jsonObject;
         }
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
@@ -93,18 +107,65 @@ namespace LEGO.AsyncAPI.Models
         }
 
         /// <summary>
+        /// Converts to <see cref="{T}" /> from an Extension.
+        /// </summary>
+        /// <typeparam name="T">T.</typeparam>
+        /// <param name="extension">The extension.</param>
+        /// <returns><see cref="{T}"/>.</returns>
+        public static T FromExtension<T>(IAsyncApiExtension extension)
+        {
+            if (extension is AsyncApiAny any)
+            {
+                return any.GetValueOrDefault<T>();
+            }
+            else
+            {
+                return default(T);
+            }
+        }
+
+        /// <summary>
         /// Gets the node.
         /// </summary>
+        /// <returns><see cref="JsonNode"/>.</returns>
         /// <value>
         /// The node.
         /// </value>
         public JsonNode GetNode() => this.node;
 
+        /// <summary>
+        /// Gets the value.
+        /// </summary>
+        /// <typeparam name="T"><see cref="{T}" />.</typeparam>
+        /// <returns><see cref="{T}" />.</returns>
         public T GetValue<T>()
         {
             return JsonSerializer.Deserialize<T>(this.node.ToJsonString());
         }
 
+        /// <summary>
+        /// Gets the value or default.
+        /// </summary>
+        /// <typeparam name="T"><see cref="{T}" />.</typeparam>
+        /// <returns><see cref="{T}" /> or default.</returns>
+        public T GetValueOrDefault<T>()
+        {
+            try
+            {
+                return this.GetValue<T>();
+            }
+            catch (System.Exception)
+            {
+                return default(T);
+            }
+        }
+
+        /// <summary>
+        /// Tries the get value.
+        /// </summary>
+        /// <typeparam name="T"><see cref="{T}" />.</typeparam>
+        /// <param name="value">The value.</param>
+        /// <returns>true if the value could be converted, otherwise false.</returns>
         public bool TryGetValue<T>(out T value)
         {
             try

--- a/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
+++ b/src/LEGO.AsyncAPI/Models/Any/AsyncApiAny.cs
@@ -43,54 +43,6 @@ namespace LEGO.AsyncAPI.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
         /// </summary>
-        /// <param name="dictionary">The dictionary.</param>
-        public AsyncApiAny(Dictionary<string, AsyncApiAny> dictionary)
-        {
-            var jsonObject = new JsonObject();
-            foreach (var kvp in dictionary)
-            {
-                jsonObject.Add(kvp.Key, kvp.Value.node);
-            }
-
-            this.node = jsonObject;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
-        /// </summary>
-        /// <param name="list">The list.</param>
-        public AsyncApiAny(List<object> list)
-        {
-            var jsonArray = new JsonArray();
-            foreach (var item in list)
-            {
-                string jsonString = JsonSerializer.Serialize(item, this.options);
-                jsonArray.Add(JsonNode.Parse(jsonString));
-            }
-
-            this.node = jsonArray;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
-        /// </summary>
-        /// <param name="dictionary">The dictionary.</param>
-        public AsyncApiAny(Dictionary<string, object> dictionary)
-        {
-            var jsonObject = new JsonObject();
-            foreach (var kvp in dictionary)
-            {
-                string jsonString = JsonSerializer.Serialize(kvp.Value, this.options);
-                jsonObject.Add(kvp.Key, JsonNode.Parse(jsonString));
-            }
-
-            this.node = jsonObject;
-        }
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AsyncApiAny"/> class.
-        /// </summary>
         /// <param name="node">The node.</param>
         public AsyncApiAny(JsonArray node)
         {

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiAnyTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiAnyTests.cs
@@ -1,0 +1,53 @@
+﻿using LEGO.AsyncAPI.Models;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LEGO.AsyncAPI.Tests
+{
+
+    public class AsyncApiAnyTests
+    {
+        [Test]
+        public void Test()
+        {
+            // Arrange
+            // Act
+            // Assert
+        }
+
+
+        [Test]
+        public void ctor_Primitives()
+        {
+            // Arrange
+            // Act
+            var a = new AsyncApiAny("string");
+            var b = new AsyncApiAny(1);
+            var c = new AsyncApiAny(1.1);
+            var d = new AsyncApiAny(true);
+            var e = new AsyncApiAny(new MyType("test"));
+            var f = new AsyncApiAny(new List<string>() { "test", "test2"});
+            var g = new AsyncApiAny(new List<MyType>() { new MyType("test") });
+            var h = new AsyncApiAny(new Dictionary<string, int>() { { "t", 2 } });
+            var i = new AsyncApiAny(new Dictionary<string, MyType>() { { "t", new MyType("test") } });
+
+            var v = e.GetValue<MyType>();
+            var k = i.GetValue<Dictionary<string, MyType>>();
+            // Assert
+        }
+
+
+        class MyType
+        {
+            public MyType(string value)
+            {
+                this.Value = value;
+            }
+            public string Value { get; set; }
+        }
+    }
+}

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -7,16 +7,21 @@ namespace LEGO.AsyncAPI.Tests
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using LEGO.AsyncAPI.Bindings.Pulsar;
     using LEGO.AsyncAPI.Bindings;
     using LEGO.AsyncAPI.Bindings.Http;
     using LEGO.AsyncAPI.Bindings.Kafka;
+    using LEGO.AsyncAPI.Bindings.Pulsar;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Readers;
     using LEGO.AsyncAPI.Writers;
     using NUnit.Framework;
 
+    public class ExtensionClass
+    {
+        public string Key { get; set; }
+        public long OtherKey { get; set; }
+    }
     public class AsyncApiDocumentV2Tests
     {
         [Test]
@@ -838,8 +843,6 @@ components:
             string traitTitle = "traitTitle";
             string schemaTitle = "schemaTitle";
             string schemaDescription = "schemaDescription";
-            string anyKey = "key";
-            string anyOtherKey = "otherKey";
             string anyStringValue = "value";
             long anyLongValue = long.MaxValue;
             string exampleSummary = "exampleSummary";
@@ -864,6 +867,8 @@ components:
             string refreshUrl = "https://example.com/refresh";
             string authorizationUrl = "https://example.com/authorization";
             string requirementString = "requirementItem";
+
+            
             var document = new AsyncApiDocument()
             {
                 Id = documentId,
@@ -1016,11 +1021,11 @@ components:
                                                         Description = schemaDescription,
                                                         Examples = new List<AsyncApiAny>
                                                         {
-                                                            new AsyncApiObject
+                                                            new AsyncApiAny(new ExtensionClass
                                                             {
-                                                                { anyKey, new AsyncApiAny(anyStringValue) },
-                                                                { anyOtherKey, new AsyncApiAny(anyLongValue) },
-                                                            },
+                                                                Key = anyStringValue,
+                                                                OtherKey = anyLongValue,
+                                                            }),
                                                         },
                                                     },
                                                     Examples = new List<AsyncApiMessageExample>
@@ -1029,11 +1034,11 @@ components:
                                                         {
                                                             Summary = exampleSummary,
                                                             Name = exampleName,
-                                                            Payload = new AsyncApiObject
+                                                            Payload =new AsyncApiAny(new ExtensionClass
                                                             {
-                                                                { anyKey, new AsyncApiAny(anyStringValue) },
-                                                                { anyOtherKey, new AsyncApiAny(anyLongValue) },
-                                                            },
+                                                                Key = anyStringValue,
+                                                                OtherKey = anyLongValue,
+                                                            }),
                                                             Extensions = new Dictionary<string, IAsyncApiExtension>
                                                             {
                                                                 { extensionKey, new AsyncApiAny(extensionString) },

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
@@ -383,7 +383,7 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
             var binding = new AsyncApiStringReader(settings).ReadFragment<AsyncApiOperation>(actual, AsyncApiVersion.AsyncApi2_0, out _);
             var binding2 = new AsyncApiStringReader(settings).ReadFragment<AsyncApiOperation>(expected, AsyncApiVersion.AsyncApi2_0, out _);
             binding2.Bindings.First().Value.Extensions.TryGetValue("x-bindingExtension", out IAsyncApiExtension any);
-            var val = AsyncApiAny.FromExtension<ExtensionClass>(any);
+            var val = AsyncApiAny.FromExtensionOrDefault<ExtensionClass>(any);
 
             // Assert
             Assert.AreEqual(actual, expected);

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
@@ -381,12 +381,19 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
             var settings = new AsyncApiReaderSettings();
             settings.Bindings = BindingsCollection.Sns;
             var binding = new AsyncApiStringReader(settings).ReadFragment<AsyncApiOperation>(actual, AsyncApiVersion.AsyncApi2_0, out _);
+            var binding2 = new AsyncApiStringReader(settings).ReadFragment<AsyncApiOperation>(expected, AsyncApiVersion.AsyncApi2_0, out _);
+            binding2.Bindings.First().Value.Extensions.TryGetValue("x-bindingExtension", out IAsyncApiExtension any);
+            var val = AsyncApiAny.FromExtension<ExtensionClass>(any);
 
             // Assert
             Assert.AreEqual(actual, expected);
 
             var expectedSnsBinding = (SnsOperationBinding)operation.Bindings.Values.First();
             expectedSnsBinding.Should().BeEquivalentTo((SnsOperationBinding)binding.Bindings.Values.First(), options => options.IgnoringCyclicReferences());
+        }
+        class ExtensionClass
+        {
+            public string bindingXPropertyName { get; set; }
         }
     }
 }

--- a/test/LEGO.AsyncAPI.Tests/LEGO.AsyncAPI.Tests.csproj
+++ b/test/LEGO.AsyncAPI.Tests/LEGO.AsyncAPI.Tests.csproj
@@ -24,7 +24,6 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiAnyTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiAnyTests.cs
@@ -3,8 +3,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LEGO.AsyncAPI.Tests
 {
@@ -22,9 +20,10 @@ namespace LEGO.AsyncAPI.Tests
             var d = new AsyncApiAny(true);
             var e = new AsyncApiAny(new MyType("test"));
             var f = new AsyncApiAny(new List<string>() { "test", "test2"});
-            var g = new AsyncApiAny(new List<MyType>() { new MyType("test") });
-            var h = new AsyncApiAny(new Dictionary<string, int>() { { "t", 2 } });
-            var i = new AsyncApiAny(new Dictionary<string, MyType>() { { "t", new MyType("test") } });
+            var g = new AsyncApiAny(new List<string>() { "test", "test2"}.AsEnumerable());
+            var h = new AsyncApiAny(new List<MyType>() { new MyType("test") });
+            var i = new AsyncApiAny(new Dictionary<string, int>() { { "t", 2 } });
+            var j = new AsyncApiAny(new Dictionary<string, MyType>() { { "t", new MyType("test") } });
 
             // Assert
             Assert.AreEqual("string", a.GetValue<string>());
@@ -34,10 +33,12 @@ namespace LEGO.AsyncAPI.Tests
             Assert.NotNull(e.GetValue<MyType>());
             Assert.IsNotEmpty(f.GetValue<List<string>>());
             Assert.IsNotEmpty(f.GetValue<IEnumerable<string>>());
-            Assert.IsNotEmpty(g.GetValue<List<MyType>>());
-            Assert.IsNotEmpty(g.GetValue<IEnumerable<MyType>>());
-            Assert.IsNotEmpty(h.GetValue<Dictionary<string, int>>());
-            Assert.IsNotEmpty(i.GetValue<Dictionary<string, MyType>>());
+            Assert.IsNotEmpty(g.GetValue<List<string>>());
+            Assert.IsNotEmpty(g.GetValue<IEnumerable<string>>());
+            Assert.IsNotEmpty(h.GetValue<List<MyType>>());
+            Assert.IsNotEmpty(h.GetValue<IEnumerable<MyType>>());
+            Assert.IsNotEmpty(i.GetValue<Dictionary<string, int>>());
+            Assert.IsNotEmpty(j.GetValue<Dictionary<string, MyType>>());
         }
 
         class MyType

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiAnyTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiAnyTests.cs
@@ -12,16 +12,7 @@ namespace LEGO.AsyncAPI.Tests
     public class AsyncApiAnyTests
     {
         [Test]
-        public void Test()
-        {
-            // Arrange
-            // Act
-            // Assert
-        }
-
-
-        [Test]
-        public void ctor_Primitives()
+        public void GetValue_ReturnsCorrectConversions()
         {
             // Arrange
             // Act
@@ -35,11 +26,19 @@ namespace LEGO.AsyncAPI.Tests
             var h = new AsyncApiAny(new Dictionary<string, int>() { { "t", 2 } });
             var i = new AsyncApiAny(new Dictionary<string, MyType>() { { "t", new MyType("test") } });
 
-            var v = e.GetValue<MyType>();
-            var k = i.GetValue<Dictionary<string, MyType>>();
             // Assert
+            Assert.AreEqual("string", a.GetValue<string>());
+            Assert.AreEqual(1, b.GetValue<int>());
+            Assert.AreEqual(1.1, c.GetValue<decimal>());
+            Assert.AreEqual(true, d.GetValue<bool>());
+            Assert.NotNull(e.GetValue<MyType>());
+            Assert.IsNotEmpty(f.GetValue<List<string>>());
+            Assert.IsNotEmpty(f.GetValue<IEnumerable<string>>());
+            Assert.IsNotEmpty(g.GetValue<List<MyType>>());
+            Assert.IsNotEmpty(g.GetValue<IEnumerable<MyType>>());
+            Assert.IsNotEmpty(h.GetValue<Dictionary<string, int>>());
+            Assert.IsNotEmpty(i.GetValue<Dictionary<string, MyType>>());
         }
-
 
         class MyType
         {
@@ -47,6 +46,7 @@ namespace LEGO.AsyncAPI.Tests
             {
                 this.Value = value;
             }
+
             public string Value { get; set; }
         }
     }

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiAnyTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiAnyTests.cs
@@ -28,7 +28,7 @@ namespace LEGO.AsyncAPI.Tests
             // Assert
             Assert.AreEqual("string", a.GetValue<string>());
             Assert.AreEqual(1, b.GetValue<int>());
-            Assert.AreEqual(1.1, c.GetValue<decimal>());
+            Assert.AreEqual(1.1, c.GetValue<double>());
             Assert.AreEqual(true, d.GetValue<bool>());
             Assert.NotNull(e.GetValue<MyType>());
             Assert.IsNotEmpty(f.GetValue<List<string>>());


### PR DESCRIPTION
## About the PR
Fixes some issues with working with AsyncApiAny, figuring out the correct types etc.
Added new GetValue type methods for extracting expected values.
These use `system.text.json` to deserialize to `T` from the `JsonNode` type.

Added a static FromExtension method, to remove redundant type casting.
So instead of 
```csharp
if (TryGetValue(key, out IAsyncApiExtension extension))
{
  var myType = (extension as AsyncApiAny).GetValue<MyType>();
}
```
You do
```csharp
if (TryGetValue(key, out IAsyncApiExtension extension))
{
  var myType = AsyncApiAny.FromExtensionOrDefault<MyType>(extension);
}
```

Added new constructor allowing for much simpler `AsyncApiAny` initialization, utlizing `system.json.text` to figure out the JsonNode type.

### Changelog
- Added: `GetValue<T>()`
- Added: `GetValueOrDefault<T>()`
- Added: `TryGetValue<T>()`
- Added: static `FromExtensionOrDefault<T>(IAsyncApiExtension extension)`
- Added: new constructor to allow for easier object creation.
- Obsoleted: `AsyncApiArray`
- Obsoleted: `AsyncApiObject`

