### PR TITLE
refactor: target netstandard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@
 
 # SA1623: Property summary documentation should match accessors
 dotnet_diagnostic.SA1623.severity = suggestion
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none

--- a/AsyncAPI.sln
+++ b/AsyncAPI.sln
@@ -12,9 +12,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DE167614-5BCB-4046-BD4C-ABB70E9F3462}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Common.Build.props = Common.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LEGO.AsyncAPI.Bindings", "src\LEGO.AsyncAPI.Bindings\LEGO.AsyncAPI.Bindings.csproj", "{33CA31F4-ECFE-4227-BFE9-F49783DD29A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LEGO.AsyncAPI.Bindings", "src\LEGO.AsyncAPI.Bindings\LEGO.AsyncAPI.Bindings.csproj", "{33CA31F4-ECFE-4227-BFE9-F49783DD29A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Common.Build.props
+++ b/Common.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Common Properties used by all assemblies -->
+  <PropertyGroup>
+    <LangVersion>10</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Company>The LEGO Group</Company>
+    <PackageProjectUrl>https://github.com/LEGO/AsyncAPI.NET</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/LEGO/AsyncAPI.NET</RepositoryUrl>
+    <PackageTags>asyncapi .net openapi documentation</PackageTags>
+  </PropertyGroup>
+</Project>

--- a/src/LEGO.AsyncAPI.Bindings/BindingsCollection.cs
+++ b/src/LEGO.AsyncAPI.Bindings/BindingsCollection.cs
@@ -19,8 +19,15 @@ namespace LEGO.AsyncAPI.Bindings
     IEnumerable<TItem> source)
     where TCollection : ICollection<TItem>
         {
-            ArgumentNullException.ThrowIfNull(destination);
-            ArgumentNullException.ThrowIfNull(source);
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
 
             if (destination is List<TItem> list)
             {

--- a/src/LEGO.AsyncAPI.Bindings/LEGO.AsyncAPI.Bindings.csproj
+++ b/src/LEGO.AsyncAPI.Bindings/LEGO.AsyncAPI.Bindings.csproj
@@ -1,20 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../Common.Build.props"/>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-	<Company>The LEGO Group</Company>
-	<PackageProjectUrl>https://github.com/LEGO/AsyncAPI.NET</PackageProjectUrl>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<Description>AsyncAPI.NET Bindings</Description>
-	<PackageTags>asyncapi .net openapi documentation</PackageTags>
-	<PackageId>AsyncAPI.NET.Bindings</PackageId>
-	<AssemblyName>LEGO.AsyncAPI.Bindings</AssemblyName>
-	<RootNamespace>LEGO.AsyncAPI.Bindings</RootNamespace>
-	<RepositoryUrl>https://github.com/LEGO/AsyncAPI.NET</RepositoryUrl>
+	  <Description>AsyncAPI.NET Bindings</Description>
+	  <PackageId>AsyncAPI.NET.Bindings</PackageId>
+	  <AssemblyName>LEGO.AsyncAPI.Bindings</AssemblyName>
+	  <RootNamespace>LEGO.AsyncAPI.Bindings</RootNamespace>
   </PropertyGroup>
-
-	
   <ItemGroup>
     <None Remove="stylecop.json" />
   </ItemGroup>

--- a/src/LEGO.AsyncAPI.Readers/JsonHelper.cs
+++ b/src/LEGO.AsyncAPI.Readers/JsonHelper.cs
@@ -4,15 +4,49 @@ namespace LEGO.AsyncAPI.Readers
 {
     using System;
     using System.Globalization;
+    using System.IO;
+    using System.Text.Encodings.Web;
+    using System.Text.Json;
     using System.Text.Json.Nodes;
     using LEGO.AsyncAPI.Exceptions;
 
+    /// <summary>
+    /// Contains helper methods for working with Json 
+    /// </summary>
     internal static class JsonHelper
     {
-        public static string GetScalarValue(this JsonNode node)
+        private static readonly JsonWriterOptions WriterOptions;
+
+        static JsonHelper()
         {
-            var scalarNode = node is JsonValue value ? value : throw new AsyncApiException($"Expected scalar value");
-            return Convert.ToString(scalarNode.GetValue<object>(), CultureInfo.InvariantCulture);
+            WriterOptions = new JsonWriterOptions()
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                Indented = false,
+                MaxDepth = 1,
+                SkipValidation = true,
+            };
+        }
+
+        /// <summary>
+        /// Takes a <see cref="JsonValue"/> and converts it into a string value.
+        /// </summary>
+        /// <param name="jsonValue">The node to convert.</param>
+        /// <returns>The string value.</returns>
+        public static string GetScalarValue(this JsonValue jsonValue)
+        {
+            using (MemoryStream memoryStream = new MemoryStream())
+            using (Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream, WriterOptions))
+            {
+                jsonValue.WriteTo(writer);
+                writer.Flush();
+                memoryStream.Position = 0;
+                using (StreamReader reader = new StreamReader(memoryStream))
+                {
+                    string value = reader.ReadToEnd();
+                    return value.Trim('"');
+                }
+            }
         }
 
         public static JsonNode ParseJsonString(string jsonString)

--- a/src/LEGO.AsyncAPI.Readers/LEGO.AsyncAPI.Readers.csproj
+++ b/src/LEGO.AsyncAPI.Readers/LEGO.AsyncAPI.Readers.csproj
@@ -1,18 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../../Common.Build.props"/>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
-	<Company>The LEGO Group</Company>
-	<PackageProjectUrl>https://github.com/LEGO/AsyncAPI.NET</PackageProjectUrl>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<Description>AsyncAPI.NET Readers for JSON and YAML documents</Description>
-	<PackageTags>asyncapi .net openapi documentation</PackageTags>
-	<PackageId>AsyncAPI.NET.Readers</PackageId>
-	<AssemblyName>LEGO.AsyncAPI.Readers</AssemblyName>
-	<RootNamespace>LEGO.AsyncAPI.Readers</RootNamespace>
-	<RepositoryUrl>https://github.com/LEGO/AsyncAPI.NET</RepositoryUrl>
+	  <Description>AsyncAPI.NET Readers for JSON and YAML documents</Description>
+	  <PackageId>AsyncAPI.NET.Readers</PackageId>
+	  <AssemblyName>LEGO.AsyncAPI.Readers</AssemblyName>
+	  <RootNamespace>LEGO.AsyncAPI.Readers</RootNamespace>
   </PropertyGroup>	
 
   <ItemGroup>

--- a/src/LEGO.AsyncAPI.Readers/ParseNodes/MapNode.cs
+++ b/src/LEGO.AsyncAPI.Readers/ParseNodes/MapNode.cs
@@ -196,7 +196,7 @@ namespace LEGO.AsyncAPI.Readers.ParseNodes
                 return null;
             }
 
-            return refNode.GetScalarValue();
+            return refNode.AsValue().GetScalarValue();
         }
 
         public string GetScalarValue(ValueNode key)

--- a/src/LEGO.AsyncAPI.Readers/ParseNodes/ValueNode.cs
+++ b/src/LEGO.AsyncAPI.Readers/ParseNodes/ValueNode.cs
@@ -26,7 +26,7 @@ namespace LEGO.AsyncAPI.Readers.ParseNodes
         {
             if (this.cachedScalarValue == null)
             {
-                this.cachedScalarValue = this.node.GetScalarValue();
+                this.cachedScalarValue = this.node.AsValue().GetScalarValue();
             }
 
             return this.cachedScalarValue;

--- a/src/LEGO.AsyncAPI.Readers/YamlConverter.cs
+++ b/src/LEGO.AsyncAPI.Readers/YamlConverter.cs
@@ -47,22 +47,41 @@
             };
         }
 
-        private static JsonValue ToJsonValue(this YamlScalarNode yaml)
+        public static JsonValue ToJsonValue(this YamlScalarNode yaml)
         {
+            string value = yaml.Value;
+
             switch (yaml.Style)
             {
                 case ScalarStyle.Plain:
-                    return decimal.TryParse(yaml.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
-                        ? JsonValue.Create(d)
-                        : bool.TryParse(yaml.Value, out var b)
-                            ? JsonValue.Create(b)
-                            : JsonValue.Create(yaml.Value)!;
+                    // We need to guess the types just based on it's format, so that means parsing
+                    if (int.TryParse(value, out int intValue))
+                    {
+                        return JsonValue.Create<int>(intValue);
+                    }
+
+                    if (double.TryParse(value, out double doubleValue))
+                    {
+                        return JsonValue.Create<double>(doubleValue);
+                    }
+
+                    if (DateTime.TryParse(value, out DateTime dateTimeValue))
+                    {
+                        return JsonValue.Create<DateTime>(dateTimeValue);
+                    }
+
+                    if (bool.TryParse(value, out bool boolValue))
+                    {
+                        return JsonValue.Create<bool>(boolValue);
+                    }
+
+                    return JsonValue.Create<string>(value);
                 case ScalarStyle.SingleQuoted:
                 case ScalarStyle.DoubleQuoted:
                 case ScalarStyle.Literal:
                 case ScalarStyle.Folded:
                 case ScalarStyle.Any:
-                    return JsonValue.Create(yaml.Value);
+                    return JsonValue.Create<string>(yaml.Value);
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj
+++ b/src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj
@@ -1,19 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../../Common.Build.props"/>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-	<Company>The LEGO Group</Company>
-	<PackageProjectUrl>https://github.com/LEGO/AsyncAPI.NET</PackageProjectUrl>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<Description>AsyncAPI.NET models</Description>
-	<PackageTags>asyncapi .net openapi documentation</PackageTags>
-	<PackageId>AsyncAPI.NET</PackageId>
-	<AssemblyName>LEGO.AsyncAPI</AssemblyName>
-	<RootNamespace>LEGO.AsyncAPI</RootNamespace>
-	<RepositoryUrl>https://github.com/LEGO/AsyncAPI.NET</RepositoryUrl>
+	  <Description>AsyncAPI.NET models</Description>
+	  <PackageId>AsyncAPI.NET</PackageId>
+	  <AssemblyName>LEGO.AsyncAPI</AssemblyName>
+	  <RootNamespace>LEGO.AsyncAPI</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="stylecop.json" />
   </ItemGroup>
@@ -27,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
 
 	  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 		  <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>

--- a/src/LEGO.AsyncAPI/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/LEGO.AsyncAPI/Writers/SpecialCharacterStringExtensions.cs
@@ -5,9 +5,12 @@ namespace LEGO.AsyncAPI.Writers
     using System;
     using System.Globalization;
     using System.Linq;
+    using System.Text.RegularExpressions;
 
     public static class SpecialCharacterStringExtensions
     {
+        private static readonly Regex numberRegex = new Regex("^[+-]?[0-9]*\\.?[0-9]*$", RegexOptions.Compiled);
+
         // Plain style strings cannot start with indicators.
         // http://www.yaml.org/spec/1.2/spec.html#indicator//
         private static readonly char[] yamlIndicators =
@@ -206,8 +209,7 @@ namespace LEGO.AsyncAPI.Writers
             }
 
             // Handle numbers
-            char first = input[0];
-            if (char.IsDigit(first) || first == '-' || first == '+') 
+            if (numberRegex.IsMatch(input))
             {
                 return $"'{input}'";
             }

--- a/src/LEGO.AsyncAPI/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/LEGO.AsyncAPI/Writers/SpecialCharacterStringExtensions.cs
@@ -9,7 +9,7 @@ namespace LEGO.AsyncAPI.Writers
 
     public static class SpecialCharacterStringExtensions
     {
-        private static readonly Regex numberRegex = new Regex("^[+-]?[0-9]*\\.?[0-9]*$", RegexOptions.Compiled);
+        private static readonly Regex numberRegex = new Regex("^[+-]?[0-9]*\\.?[0-9]*$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         // Plain style strings cannot start with indicators.
         // http://www.yaml.org/spec/1.2/spec.html#indicator//

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -26,13 +26,13 @@ namespace LEGO.AsyncAPI.Tests
     public class AsyncApiDocumentV2Tests
     {
         [Test]
-        public void AsyncApiDocumentYaml_DefalutVersionNumber_IsWrappedInSingleQuotes()
+        public void AsyncApiDocumentYaml_DefalutVersionNumber_IsNotWrappedInSingleQuotes()
         {
             string actual = new AsyncApiDocumentBuilder()
                 .Build()
                 .SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
 
-            Assert.AreEqual("asyncapi: '2.6.0'\ninfo: { }", actual);
+            Assert.AreEqual("asyncapi: 2.6.0\ninfo: { }", actual);
         }
 
         [Test]
@@ -40,10 +40,10 @@ namespace LEGO.AsyncAPI.Tests
         {
             // Arrange
             var expected =
-@"asyncapi: '2.6.0'
+@"asyncapi: 2.6.0
 info:
   title: Streetlights Kafka API
-  version: '1.0.0'
+  version: 1.0.0
   description: The Smartylighting Streetlights API allows you to remotely manage the city lights.
   license:
     name: Apache 2.0
@@ -715,7 +715,7 @@ components:
         public void SerializeV2_WithFullSpec_Serializes()
         {
             var expected =
-                @"asyncapi: '2.6.0'
+                @"asyncapi: 2.6.0
 info:
   title: apiTitle
   version: apiVersion
@@ -1231,7 +1231,7 @@ components:
         [Test]
         public void Serializev2_WithBindings_Serializes()
         {
-            var expected = @"asyncapi: '2.6.0'
+            var expected = @"asyncapi: 2.6.0
 info:
   description: test description
 servers:

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -22,8 +22,19 @@ namespace LEGO.AsyncAPI.Tests
         public string Key { get; set; }
         public long OtherKey { get; set; }
     }
+
     public class AsyncApiDocumentV2Tests
     {
+        [Test]
+        public void AsyncApiDocumentYaml_DefalutVersionNumber_IsWrappedInSingleQuotes()
+        {
+            string actual = new AsyncApiDocumentBuilder()
+                .Build()
+                .SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
+
+            Assert.AreEqual("asyncapi: '2.6.0'\ninfo: { }", actual);
+        }
+
         [Test]
         public void AsyncApiDocument_WithStreetLightsExample_SerializesAndDeserializes()
         {
@@ -32,7 +43,7 @@ namespace LEGO.AsyncAPI.Tests
 @"asyncapi: '2.6.0'
 info:
   title: Streetlights Kafka API
-  version: 1.0.0
+  version: '1.0.0'
   description: The Smartylighting Streetlights API allows you to remotely manage the city lights.
   license:
     name: Apache 2.0
@@ -200,25 +211,25 @@ components:
             maximum: 100
             minimum: 0";
 
-        var asyncApiDocument = new AsyncApiDocumentBuilder()
-            .WithInfo(new AsyncApiInfo
-            {
-                Title = "Streetlights Kafka API",
-                Version = "1.0.0",
-                Description = "The Smartylighting Streetlights API allows you to remotely manage the city lights.",
-                License = new AsyncApiLicense
+            var asyncApiDocument = new AsyncApiDocumentBuilder()
+                .WithInfo(new AsyncApiInfo
                 {
-                    Name = "Apache 2.0",
-                    Url = new Uri("https://www.apache.org/licenses/LICENSE-2.0"),
-                },
-            })
-            .WithServer("scram-connections", new AsyncApiServer
-            {
-                Url = "test.mykafkacluster.org:18092",
-                Protocol = "kafka-secure",
-                Description = "Test broker secured with scramSha256",
-                Security = new List<AsyncApiSecurityRequirement>
+                    Title = "Streetlights Kafka API",
+                    Version = "1.0.0",
+                    Description = "The Smartylighting Streetlights API allows you to remotely manage the city lights.",
+                    License = new AsyncApiLicense
+                    {
+                        Name = "Apache 2.0",
+                        Url = new Uri("https://www.apache.org/licenses/LICENSE-2.0"),
+                    },
+                })
+                .WithServer("scram-connections", new AsyncApiServer
                 {
+                    Url = "test.mykafkacluster.org:18092",
+                    Protocol = "kafka-secure",
+                    Description = "Test broker secured with scramSha256",
+                    Security = new List<AsyncApiSecurityRequirement>
+                    {
                     new AsyncApiSecurityRequirement
                     {
                         {
@@ -232,9 +243,9 @@ components:
                             }, new List<string>()
                         },
                     },
-                },
-                Tags = new List<AsyncApiTag>
-                {
+                    },
+                    Tags = new List<AsyncApiTag>
+                    {
                     new AsyncApiTag
                     {
                         Name = "env:test-scram",
@@ -250,15 +261,15 @@ components:
                         Name = "visibility:private",
                         Description = "This resource is private and only available to certain users",
                     },
-                },
-            })
-            .WithServer("mtls-connections", new AsyncApiServer
-            {
-                Url = "test.mykafkacluster.org:28092",
-                Protocol = "kafka-secure",
-                Description = "Test broker secured with X509",
-                Security = new List<AsyncApiSecurityRequirement>
+                    },
+                })
+                .WithServer("mtls-connections", new AsyncApiServer
                 {
+                    Url = "test.mykafkacluster.org:28092",
+                    Protocol = "kafka-secure",
+                    Description = "Test broker secured with X509",
+                    Security = new List<AsyncApiSecurityRequirement>
+                    {
                     new AsyncApiSecurityRequirement
                     {
                         {
@@ -272,9 +283,9 @@ components:
                             }, new List<string>()
                         },
                     },
-                },
-                Tags = new List<AsyncApiTag>
-                {
+                    },
+                    Tags = new List<AsyncApiTag>
+                    {
                     new AsyncApiTag
                     {
                         Name = "env:test-mtls",
@@ -290,16 +301,16 @@ components:
                         Name = "visibility:private",
                         Description = "This resource is private and only available to certain users",
                     },
-                },
-            })
-            .WithDefaultContentType()
-            .WithChannel(
-            "smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured",
-            new AsyncApiChannel()
-            {
-                Description = "The topic on which measured values may be produced and consumed.",
-                Parameters = new Dictionary<string, AsyncApiParameter>
+                    },
+                })
+                .WithDefaultContentType()
+                .WithChannel(
+                "smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured",
+                new AsyncApiChannel()
                 {
+                    Description = "The topic on which measured values may be produced and consumed.",
+                    Parameters = new Dictionary<string, AsyncApiParameter>
+                    {
                     {
                         "streetlightId", new AsyncApiParameter()
                         {
@@ -310,13 +321,13 @@ components:
                             },
                         }
                     },
-                },
-                Publish = new AsyncApiOperation()
-                {
-                    Summary = "Inform about environmental lighting conditions of a particular streetlight.",
-                    OperationId = "receiveLightMeasurement",
-                    Traits = new List<AsyncApiOperationTrait>
+                    },
+                    Publish = new AsyncApiOperation()
                     {
+                        Summary = "Inform about environmental lighting conditions of a particular streetlight.",
+                        OperationId = "receiveLightMeasurement",
+                        Traits = new List<AsyncApiOperationTrait>
+                        {
                         new AsyncApiOperationTrait()
                         {
                             Reference = new AsyncApiReference()
@@ -325,9 +336,9 @@ components:
                                 Type = ReferenceType.OperationTrait,
                             },
                         },
-                    },
-                    Message = new List<AsyncApiMessage>
-                    {
+                        },
+                        Message = new List<AsyncApiMessage>
+                        {
                         new AsyncApiMessage()
                         {
                             Reference = new AsyncApiReference()
@@ -336,15 +347,15 @@ components:
                                 Type = ReferenceType.Message,
                             },
                         },
+                        },
                     },
-                },
-            })
-            .WithChannel(
-            "smartylighting.streetlights.1.0.action.{streetlightId}.turn.on",
-            new AsyncApiChannel()
-            {
-                Parameters = new Dictionary<string, AsyncApiParameter>
+                })
+                .WithChannel(
+                "smartylighting.streetlights.1.0.action.{streetlightId}.turn.on",
+                new AsyncApiChannel()
                 {
+                    Parameters = new Dictionary<string, AsyncApiParameter>
+                    {
                     {
                         "streetlightId", new AsyncApiParameter()
                         {
@@ -355,12 +366,12 @@ components:
                             },
                         }
                     },
-                },
-                Subscribe = new AsyncApiOperation()
-                {
-                    OperationId = "turnOn",
-                    Traits = new List<AsyncApiOperationTrait>
+                    },
+                    Subscribe = new AsyncApiOperation()
                     {
+                        OperationId = "turnOn",
+                        Traits = new List<AsyncApiOperationTrait>
+                        {
                         new AsyncApiOperationTrait()
                         {
                             Reference = new AsyncApiReference()
@@ -369,9 +380,9 @@ components:
                                 Type = ReferenceType.OperationTrait,
                             },
                         },
-                    },
-                    Message = new List<AsyncApiMessage>
-                    {
+                        },
+                        Message = new List<AsyncApiMessage>
+                        {
                         new AsyncApiMessage()
                         {
                             Reference = new AsyncApiReference()
@@ -380,15 +391,15 @@ components:
                                 Type = ReferenceType.Message,
                             },
                         },
+                        },
                     },
-                },
-            })
-            .WithChannel(
-            "smartylighting.streetlights.1.0.action.{streetlightId}.turn.off",
-            new AsyncApiChannel()
-            {
-                Parameters = new Dictionary<string, AsyncApiParameter>
+                })
+                .WithChannel(
+                "smartylighting.streetlights.1.0.action.{streetlightId}.turn.off",
+                new AsyncApiChannel()
                 {
+                    Parameters = new Dictionary<string, AsyncApiParameter>
+                    {
                     {
                         "streetlightId", new AsyncApiParameter()
                         {
@@ -399,12 +410,12 @@ components:
                             },
                         }
                     },
-                },
-                Subscribe = new AsyncApiOperation()
-                {
-                    OperationId = "turnOff",
-                    Traits = new List<AsyncApiOperationTrait>
+                    },
+                    Subscribe = new AsyncApiOperation()
                     {
+                        OperationId = "turnOff",
+                        Traits = new List<AsyncApiOperationTrait>
+                        {
                         new AsyncApiOperationTrait()
                         {
                             Reference = new AsyncApiReference()
@@ -413,9 +424,9 @@ components:
                                 Type = ReferenceType.OperationTrait,
                             },
                         },
-                    },
-                    Message = new List<AsyncApiMessage>
-                    {
+                        },
+                        Message = new List<AsyncApiMessage>
+                        {
                         new AsyncApiMessage()
                         {
                             Reference = new AsyncApiReference()
@@ -424,15 +435,15 @@ components:
                                 Type = ReferenceType.Message,
                             },
                         },
+                        },
                     },
-                },
-            })
-            .WithChannel(
-            "smartylighting.streetlights.1.0.action.{streetlightId}.dim",
-            new AsyncApiChannel()
-            {
-                Parameters = new Dictionary<string, AsyncApiParameter>
+                })
+                .WithChannel(
+                "smartylighting.streetlights.1.0.action.{streetlightId}.dim",
+                new AsyncApiChannel()
                 {
+                    Parameters = new Dictionary<string, AsyncApiParameter>
+                    {
                     {
                         "streetlightId", new AsyncApiParameter()
                         {
@@ -443,12 +454,12 @@ components:
                             },
                         }
                     },
-                },
-                Subscribe = new AsyncApiOperation()
-                {
-                    OperationId = "dimLight",
-                    Traits = new List<AsyncApiOperationTrait>
+                    },
+                    Subscribe = new AsyncApiOperation()
                     {
+                        OperationId = "dimLight",
+                        Traits = new List<AsyncApiOperationTrait>
+                        {
                         new AsyncApiOperationTrait()
                         {
                             Reference = new AsyncApiReference()
@@ -457,9 +468,9 @@ components:
                                 Type = ReferenceType.OperationTrait,
                             },
                         },
-                    },
-                    Message = new List<AsyncApiMessage>
-                    {
+                        },
+                        Message = new List<AsyncApiMessage>
+                        {
                         new AsyncApiMessage()
                         {
                             Reference = new AsyncApiReference()
@@ -468,17 +479,17 @@ components:
                                 Type = ReferenceType.Message,
                             },
                         },
+                        },
                     },
-                },
-            })
-            .WithComponent("lightMeasured", new AsyncApiMessage()
-            {
-                Name = "lightMeasured",
-                Title = "Light measured",
-                Summary = "Inform about environmental lighting conditions of a particular streetlight.",
-                ContentType = "application/json",
-                Traits = new List<AsyncApiMessageTrait>()
+                })
+                .WithComponent("lightMeasured", new AsyncApiMessage()
                 {
+                    Name = "lightMeasured",
+                    Title = "Light measured",
+                    Summary = "Inform about environmental lighting conditions of a particular streetlight.",
+                    ContentType = "application/json",
+                    Traits = new List<AsyncApiMessageTrait>()
+                    {
                     new AsyncApiMessageTrait()
                     {
                         Reference = new AsyncApiReference()
@@ -487,23 +498,23 @@ components:
                             Id = "commonHeaders",
                         },
                     },
-                },
-                Payload = new AsyncApiSchema()
-                {
-                    Reference = new AsyncApiReference()
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = "lightMeasuredPayload",
                     },
-                },
-            })
-            .WithComponent("turnOnOff", new AsyncApiMessage()
-            {
-                Name = "turnOnOff",
-                Title = "Turn on/off",
-                Summary = "Command a particular streetlight to turn the lights on or off.",
-                Traits = new List<AsyncApiMessageTrait>()
+                    Payload = new AsyncApiSchema()
+                    {
+                        Reference = new AsyncApiReference()
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = "lightMeasuredPayload",
+                        },
+                    },
+                })
+                .WithComponent("turnOnOff", new AsyncApiMessage()
                 {
+                    Name = "turnOnOff",
+                    Title = "Turn on/off",
+                    Summary = "Command a particular streetlight to turn the lights on or off.",
+                    Traits = new List<AsyncApiMessageTrait>()
+                    {
                     new AsyncApiMessageTrait()
                     {
                         Reference = new AsyncApiReference()
@@ -512,23 +523,23 @@ components:
                             Id = "commonHeaders",
                         },
                     },
-                },
-                Payload = new AsyncApiSchema()
-                {
-                    Reference = new AsyncApiReference()
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = "turnOnOffPayload",
                     },
-                },
-            })
-            .WithComponent("dimLight", new AsyncApiMessage()
-            {
-                Name = "dimLight",
-                Title = "Dim light",
-                Summary = "Command a particular streetlight to dim the lights.",
-                Traits = new List<AsyncApiMessageTrait>()
+                    Payload = new AsyncApiSchema()
+                    {
+                        Reference = new AsyncApiReference()
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = "turnOnOffPayload",
+                        },
+                    },
+                })
+                .WithComponent("dimLight", new AsyncApiMessage()
                 {
+                    Name = "dimLight",
+                    Title = "Dim light",
+                    Summary = "Command a particular streetlight to dim the lights.",
+                    Traits = new List<AsyncApiMessageTrait>()
+                    {
                     new AsyncApiMessageTrait()
                     {
                         Reference = new AsyncApiReference()
@@ -537,21 +548,21 @@ components:
                             Id = "commonHeaders",
                         },
                     },
-                },
-                Payload = new AsyncApiSchema()
-                {
-                    Reference = new AsyncApiReference()
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = "dimLightPayload",
                     },
-                },
-            })
-            .WithComponent("lightMeasuredPayload", new AsyncApiSchema()
-            {
-                Type = SchemaType.Object,
-                Properties = new Dictionary<string, AsyncApiSchema>()
+                    Payload = new AsyncApiSchema()
+                    {
+                        Reference = new AsyncApiReference()
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = "dimLightPayload",
+                        },
+                    },
+                })
+                .WithComponent("lightMeasuredPayload", new AsyncApiSchema()
                 {
+                    Type = SchemaType.Object,
+                    Properties = new Dictionary<string, AsyncApiSchema>()
+                    {
                     {
                         "lumens", new AsyncApiSchema()
                         {
@@ -570,13 +581,13 @@ components:
                             },
                         }
                     },
-                },
-            })
-            .WithComponent("turnOnOffPayload", new AsyncApiSchema()
-            {
-                Type = SchemaType.Object,
-                Properties = new Dictionary<string, AsyncApiSchema>()
+                    },
+                })
+                .WithComponent("turnOnOffPayload", new AsyncApiSchema()
                 {
+                    Type = SchemaType.Object,
+                    Properties = new Dictionary<string, AsyncApiSchema>()
+                    {
                     {
                         "command", new AsyncApiSchema()
                         {
@@ -599,13 +610,13 @@ components:
                             },
                         }
                     },
-                },
-            })
-            .WithComponent("dimLightPayload", new AsyncApiSchema()
-            {
-                Type = SchemaType.Object,
-                Properties = new Dictionary<string, AsyncApiSchema>()
+                    },
+                })
+                .WithComponent("dimLightPayload", new AsyncApiSchema()
                 {
+                    Type = SchemaType.Object,
+                    Properties = new Dictionary<string, AsyncApiSchema>()
+                    {
                     {
                         "percentage", new AsyncApiSchema()
                         {
@@ -625,40 +636,40 @@ components:
                             },
                         }
                     },
-                },
-            })
-            .WithComponent("sentAt", new AsyncApiSchema()
-            {
-                Type = SchemaType.String,
-                Format = "date-time",
-                Description = "Date and time when the message was sent.",
-
-            })
-            .WithComponent("saslScram", new AsyncApiSecurityScheme
-            {
-                Type = SecuritySchemeType.ScramSha256,
-                Description = "Provide your username and password for SASL/SCRAM authentication",
-            })
-            .WithComponent("certs", new AsyncApiSecurityScheme
-            {
-                Type = SecuritySchemeType.X509,
-                Description = "Download the certificate files from service provider",
-            })
-            .WithComponent("streetlightId", new AsyncApiParameter()
-            {
-                Description = "The ID of the streetlight.",
-                Schema = new AsyncApiSchema()
+                    },
+                })
+                .WithComponent("sentAt", new AsyncApiSchema()
                 {
                     Type = SchemaType.String,
-                },
-            })
-            .WithComponent("commonHeaders", new AsyncApiMessageTrait()
-            {
-                Headers = new AsyncApiSchema()
+                    Format = "date-time",
+                    Description = "Date and time when the message was sent.",
+
+                })
+                .WithComponent("saslScram", new AsyncApiSecurityScheme
                 {
-                    Type = SchemaType.Object,
-                    Properties = new Dictionary<string, AsyncApiSchema>()
+                    Type = SecuritySchemeType.ScramSha256,
+                    Description = "Provide your username and password for SASL/SCRAM authentication",
+                })
+                .WithComponent("certs", new AsyncApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.X509,
+                    Description = "Download the certificate files from service provider",
+                })
+                .WithComponent("streetlightId", new AsyncApiParameter()
+                {
+                    Description = "The ID of the streetlight.",
+                    Schema = new AsyncApiSchema()
                     {
+                        Type = SchemaType.String,
+                    },
+                })
+                .WithComponent("commonHeaders", new AsyncApiMessageTrait()
+                {
+                    Headers = new AsyncApiSchema()
+                    {
+                        Type = SchemaType.Object,
+                        Properties = new Dictionary<string, AsyncApiSchema>()
+                        {
                         {
                             "my-app-header", new AsyncApiSchema()
                             {
@@ -667,13 +678,13 @@ components:
                                 Maximum = 100,
                             }
                         },
+                        },
                     },
-                },
-            })
-            .WithComponent("kafka", new AsyncApiOperationTrait()
-            {
-                Bindings = new AsyncApiBindings<IOperationBinding>()
+                })
+                .WithComponent("kafka", new AsyncApiOperationTrait()
                 {
+                    Bindings = new AsyncApiBindings<IOperationBinding>()
+                    {
                     {
                         "kafka", new KafkaOperationBinding()
                         {
@@ -687,9 +698,9 @@ components:
                             },
                         }
                     },
-                },
-            })
-            .Build();
+                    },
+                })
+                .Build();
 
             // Act
             var actual = asyncApiDocument.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
@@ -868,7 +879,7 @@ components:
             string authorizationUrl = "https://example.com/authorization";
             string requirementString = "requirementItem";
 
-            
+
             var document = new AsyncApiDocument()
             {
                 Id = documentId,
@@ -1171,7 +1182,7 @@ components:
                                     Id = "bindings",
                                 },
                             },
-                        } 
+                        }
                     }
                 },
                 ServerBindings = new Dictionary<string, AsyncApiBindings<IServerBinding>>()
@@ -1193,7 +1204,7 @@ components:
                         {
                             new PulsarChannelBinding()
                             {
-                                Namespace = "users", 
+                                Namespace = "users",
                                 Persistence = AsyncAPI.Models.Bindings.Pulsar.Persistence.Persistent,
                             }
                         }
@@ -1216,7 +1227,7 @@ components:
             var reader = new AsyncApiStringReader(settings);
             var deserialized = reader.Read(actual, out var diagnostic);
         }
-        
+
         [Test]
         public void Serializev2_WithBindings_Serializes()
         {

--- a/test/LEGO.AsyncAPI.Tests/LEGO.AsyncAPI.Tests.csproj
+++ b/test/LEGO.AsyncAPI.Tests/LEGO.AsyncAPI.Tests.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>11</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/LEGO.AsyncAPI.Tests/LEGO.AsyncAPI.Tests.csproj
+++ b/test/LEGO.AsyncAPI.Tests/LEGO.AsyncAPI.Tests.csproj
@@ -1,55 +1,55 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>disable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);SA1600</NoWarn>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="LiquidTestReports.Markdown" Version="1.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="JsonSchema.Net" Version="2.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ReportGenerator" Version="5.1.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.7.0" />
-		<PackageReference Include="LiquidTestReports.Markdown" Version="1.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="JsonSchema.Net" Version="2.0.1" />
-        <PackageReference Include="NUnit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="ReportGenerator" Version="5.1.2" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LEGO.AsyncAPI.Bindings\LEGO.AsyncAPI.Bindings.csproj" />
+    <ProjectReference Include="..\..\src\LEGO.AsyncAPI.Readers\LEGO.AsyncAPI.Readers.csproj" />
+    <ProjectReference Include="..\..\src\LEGO.AsyncAPI\LEGO.AsyncAPI.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\LEGO.AsyncAPI.Bindings\LEGO.AsyncAPI.Bindings.csproj" />
-      <ProjectReference Include="..\..\src\LEGO.AsyncAPI.Readers\LEGO.AsyncAPI.Readers.csproj" />
-      <ProjectReference Include="..\..\src\LEGO.AsyncAPI\LEGO.AsyncAPI.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Remove="readers\Basic.yaml" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Remove="readers\samples\AsyncApi\AsyncApiChannelObject\Basic.yaml" />
-      <None Remove="readers\samples\AsyncApi\AsyncApiInfoObject\Advanced.yaml" />
-      <None Remove="readers\samples\AsyncApi\AsyncApiInfoObject\Basic.yaml" />
-      <None Remove="readers\samples\AsyncApi\Basic.yaml" />
-      <None Remove="readers\samples\AsyncApi\schema-v2.3.0.json" />
-      <None Remove="stylecop.json" />
-    </ItemGroup>
-    <ItemGroup>
-      <AdditionalFiles Include="stylecop.json" />
-    </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Attributes\" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Include="..\..\.editorconfig" Link=".editorconfig" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="readers\Basic.yaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="readers\samples\AsyncApi\AsyncApiChannelObject\Basic.yaml" />
+    <None Remove="readers\samples\AsyncApi\AsyncApiInfoObject\Advanced.yaml" />
+    <None Remove="readers\samples\AsyncApi\AsyncApiInfoObject\Basic.yaml" />
+    <None Remove="readers\samples\AsyncApi\Basic.yaml" />
+    <None Remove="readers\samples\AsyncApi\schema-v2.3.0.json" />
+    <None Remove="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Attributes\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
 </Project>

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
@@ -284,7 +284,7 @@ namespace LEGO.AsyncAPI.Tests.Models
         };
 
         private string NoInlinedReferences =>
-            @"asyncapi: '2.6.0'
+            @"asyncapi: 2.6.0
 info:
   title: Streetlights Kafka API
   version: 1.0.0
@@ -320,7 +320,7 @@ components:
       description: test";
 
         private string InlinedReferences =>
-            @"asyncapi: '2.6.0'
+            @"asyncapi: 2.6.0
 info:
   title: Streetlights Kafka API
   version: 1.0.0

--- a/test/LEGO.AsyncAPI.Tests/Readers/YamlConverterTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Readers/YamlConverterTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Tests.Readers
+{
+    using System;
+    using System.Reflection;
+    using System.Text.Json.Nodes;
+    using LEGO.AsyncAPI.Readers;
+    using NUnit.Framework;
+    using YamlDotNet.RepresentationModel;
+
+    internal class YamlConverterTests
+    {
+        private static readonly MethodInfo GenericGetValueMethodInfo;
+
+        static YamlConverterTests()
+        {
+            GenericGetValueMethodInfo = typeof(JsonValue)
+                .GetMethod("GetValue", BindingFlags.Public | BindingFlags.Instance)!;
+        }
+
+        [Test]
+        public void ToJsonValue_PlainString_CanGetStringValue()
+            => ComposeJsonValue(
+                    input: "hello world",
+                    assertValueType: () => typeof(string));
+
+        [Test]
+        [TestCase("true")]
+        [TestCase("false")]
+        public void ToJsonValue_PlainBoolean_CanGetBoolValue(string input)
+            => ComposeJsonValue(
+                input: input,
+                assertValueType: () => typeof(bool));
+
+        [Test]
+        [TestCase("2022-12-31")] // Canonical
+        [TestCase("2022-12-31T18:59:59-05:00")] // ISO 8601 
+        [TestCase("2001-12-14 21:59:43.10 -5")] // Spaced
+        public void ToJsonValue_PlainDateTime_CanGetDateTimeValue(string input)
+            => ComposeJsonValue(
+                input: input,
+                assertValueType: () => typeof(DateTime));
+
+        [Test]
+        public void ToJsonValue_PlainInt_CanGetIntValue()
+            => ComposeJsonValue(
+                input: "2022",
+                assertValueType: () => typeof(int));
+
+        [Test]
+        public void ToJsonValue_PlainDouble_CanGetDoubleValue()
+            => ComposeJsonValue(
+                input: "2022.20",
+                assertValueType: () => typeof(double));
+
+        [Test]
+        public void GetScalarValue_PlainString_MatchesExpectedScalerValue()
+            => ComposeJsonValue(
+                    input: "hello world",
+                    assertScalerValue: () => "hello world");
+
+        [Test]
+        [TestCase("true")]
+        [TestCase("false")]
+        public void GetScalarValue_PlainBoolean_MatchesExpectedScalerValue(string input)
+            => ComposeJsonValue(
+                input: input,
+                assertScalerValue: () => input);
+
+        [Test]
+        public void GetScalarValue_PlainDateTime_MatchesExpectedScalerValue()
+            => ComposeJsonValue(
+                input: "2022-12-31T18:59:59-05:00",
+                assertScalerValue: () => "2022-12-31T18:59:59-05:00");
+
+        [Test]
+        public void GetScalarValue_PlainInt_MatchesExpectedScalerValue()
+            => ComposeJsonValue(
+                input: "2022",
+                assertScalerValue: () => "2022");
+
+        [Test]
+        public void GetScalarValue_PlainDouble_MatchesExpectedScalerValue()
+            => ComposeJsonValue(
+                input: "2022.20",
+                assertScalerValue: () => "2022.2"); // extra zero dropped
+
+        private void ComposeJsonValue(
+            string input,
+            Func<Type>? assertValueType = null,
+            Func<string>? assertScalerValue = null)
+        {
+            YamlScalarNode node = new YamlScalarNode(input)
+            {
+                Style = YamlDotNet.Core.ScalarStyle.Plain,
+            };
+
+            JsonValue jValue = node.ToJsonValue();
+
+            jValue.GetScalarValue();
+
+            if (assertValueType != null)
+            {
+                Type valueType = assertValueType();
+                MethodInfo genericGetValueMethod = GenericGetValueMethodInfo.MakeGenericMethod(valueType);
+                object? result = genericGetValueMethod.Invoke(jValue, null);
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOf(valueType, result);
+            }
+
+            if (assertScalerValue != null)
+            {
+                string expectedValue = assertScalerValue();
+                string actualValue = jValue.GetScalarValue();
+                Assert.AreEqual(expectedValue, actualValue);
+            }
+        }
+    }
+}

--- a/test/LEGO.AsyncAPI.Tests/StringExtensions.cs
+++ b/test/LEGO.AsyncAPI.Tests/StringExtensions.cs
@@ -3,9 +3,22 @@
 namespace LEGO.AsyncAPI.Tests
 {
     using System;
+    using System.IO;
 
     public static class StringExtensions
     {
+        public static Stream ToStream(this string input)
+        {
+            Stream stream = new MemoryStream();
+            using (StreamWriter writer = new StreamWriter(stream, leaveOpen: true))
+            {
+                writer.Write(input);
+            }
+
+            stream.Position = 0;
+            return stream;
+        }
+
         public static string MakeLineBreaksEnvironmentNeutral(this string input)
         {
             return input.Replace("\r\n", "\n")

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -61,6 +61,17 @@ namespace LEGO.AsyncAPI.Tests.Writers
             => this.Compose("false", "'false'");
 
         [Test]
+        public void GetYamlCompatibleString_DateTimeSlashString_WrappedWithQuotes()
+            => this.Compose("12/31/2022 23:59:59", "'12/31/2022 23:59:59'");
+           
+        [Test]
+        public void GetYamlCompatibleString_DateTimeDashString_WrappedWithQuotes()
+            => this.Compose("2022-12-31 23:59:59", "'2022-12-31 23:59:59'");
+            
+        [Test]
+        public void GetYamlCompatibleString_DateTimeISOString_NotWrappedWithQuotes()
+            => this.Compose("2022-12-31T23:59:59Z", "2022-12-31T23:59:59Z");
+        [Test]
         [TestCase("\0", "\\0")]
         [TestCase("\x01", "\\x01")]
         [TestCase("\x02", "\\x02")]

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -71,6 +71,7 @@ namespace LEGO.AsyncAPI.Tests.Writers
         [Test]
         public void GetYamlCompatibleString_DateTimeISOString_NotWrappedWithQuotes()
             => this.Compose("2022-12-31T23:59:59Z", "2022-12-31T23:59:59Z");
+
         [Test]
         [TestCase("\0", "\\0")]
         [TestCase("\x01", "\\x01")]

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Tests.Writers
+{
+    using LEGO.AsyncAPI.Writers;
+    using NUnit.Framework;
+    using System;
+
+    internal class SpecialCharacterStringExtensionsTests
+    {
+        [Test]
+        public void GetYamlCompatibleString_NullValue_ReturnsNull()
+            => this.Compose(null, "null");
+
+        [Test]
+        public void GetYamlCompatibleString_EmptyValue_ReturnsNull()
+            => this.Compose(string.Empty, "''");
+
+        [Test]
+        public void GetYamlCompatibleString_NullWordString_ReturnsWrappedValue()
+            => this.Compose("null", "'null'");
+
+        [Test]
+        public void GetYamlCompatibleString_TildaWordString_ReturnsWrappedValue()
+              => this.Compose("~", "'~'");
+
+        [Test]
+        [TestCase("\0", "\\0")]
+        [TestCase("\x01", "\\x01")]
+        [TestCase("\x02", "\\x02")]
+        [TestCase("\x03", "\\x03")]
+        [TestCase("\x04", "\\x04")]
+        [TestCase("\x05", "\\x05")]
+        [TestCase("\x06", "\\x06")]
+        [TestCase("\a", "\\a")]
+        [TestCase("\b", "\\b")]
+        [TestCase("\t", "\\t")]
+        [TestCase("\n", "\\n")]
+        [TestCase("\v", "\\v")]
+        [TestCase("\f", "\\f")]
+        [TestCase("\r", "\\r")]
+        [TestCase("\x0e", "\\x0e")]
+        [TestCase("\x0f", "\\x0f")]
+        [TestCase("\x10", "\\x10")]
+        [TestCase("\x11", "\\x11")]
+        [TestCase("\x12", "\\x12")]
+        [TestCase("\x13", "\\x13")]
+        [TestCase("\x14", "\\x14")]
+        [TestCase("\x15", "\\x15")]
+        [TestCase("\x16", "\\x16")]
+        [TestCase("\x17", "\\x17")]
+        [TestCase("\x18", "\\x18")]
+        [TestCase("\x19", "\\x19")]
+        [TestCase("\x1a", "\\x1a")]
+        [TestCase("\x1b", "\\x1b")]
+        [TestCase("\x1c", "\\x1c")]
+        [TestCase("\x1d", "\\x1d")]
+        [TestCase("\x1e", "\\x1e")]
+        [TestCase("\x1f", "\\x1f")]
+        public void GetYamlCompatibleString_ControlCharacters_AreEscaped(string input, string expected)
+          => this.Compose($"value {input}", $"'value {expected}'");
+
+        private void Compose(
+            string? input,
+            string expected)
+        {
+            string actual = SpecialCharacterStringExtensions.GetYamlCompatibleString(input);
+            Console.WriteLine($"Expected: <{expected}>");
+            Console.WriteLine($"Actual: <{actual}>");
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -58,7 +58,7 @@ namespace LEGO.AsyncAPI.Tests.Writers
 
         [Test]
         public void GetYamlCompatibleString_FalseString_WrappedWithQuotes()
-            => this.Compose("false", "'flase'");
+            => this.Compose("false", "'false'");
 
         [Test]
         [TestCase("\0", "\\0")]

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -25,6 +25,42 @@ namespace LEGO.AsyncAPI.Tests.Writers
               => this.Compose("~", "'~'");
 
         [Test]
+        public void GetYamlCompatibleString_IntegerWithTwoPeriods_RendersPlainStyle()
+            => this.Compose("1.2.3", "1.2.3");
+
+        [Test]
+        public void GetYamlCompatibleString_Float_WrappedWithQuotes()
+            => this.Compose("1.2", "'1.2'");
+
+        [Test]
+        public void GetYamlCompatibleString_PositiveFloat_WrappedWithQuotes()
+            => this.Compose("+1.2", "'+1.2'");
+
+        [Test]
+        public void GetYamlCompatibleString_NegativeFloat_WrappedWithQuotes()
+               => this.Compose("-1.2", "'-1.2'");
+
+        [Test]
+        public void GetYamlCompatibleString_PositiveInfinityFloat_WrappedWithQuotes()
+            => this.Compose(".inf", "'.inf'");
+
+        [Test]
+        public void GetYamlCompatibleString_NegativeInfinityFloat_WrappedWithQuotes()
+           => this.Compose("-.inf", "'-.inf'");
+
+        [Test]
+        public void GetYamlCompatibleString_NanFloat_WrappedWithQuotes()
+            => this.Compose(".nan", "'.nan'");
+
+        [Test]
+        public void GetYamlCompatibleString_TrueString_WrappedWithQuotes()
+            => this.Compose("true", "'true'");
+
+        [Test]
+        public void GetYamlCompatibleString_FalseString_WrappedWithQuotes()
+            => this.Compose("false", "'flase'");
+
+        [Test]
         [TestCase("\0", "\\0")]
         [TestCase("\x01", "\\x01")]
         [TestCase("\x02", "\\x02")]

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -63,14 +63,26 @@ namespace LEGO.AsyncAPI.Tests.Writers
         [Test]
         public void GetYamlCompatibleString_DateTimeSlashString_WrappedWithQuotes()
             => this.Compose("12/31/2022 23:59:59", "'12/31/2022 23:59:59'");
-           
+
         [Test]
         public void GetYamlCompatibleString_DateTimeDashString_WrappedWithQuotes()
             => this.Compose("2022-12-31 23:59:59", "'2022-12-31 23:59:59'");
-            
+
         [Test]
         public void GetYamlCompatibleString_DateTimeISOString_NotWrappedWithQuotes()
             => this.Compose("2022-12-31T23:59:59Z", "2022-12-31T23:59:59Z");
+
+        [Test]
+        public void GetYamlCompatibleString_DateTimeCanonicalString_NotWrappedWithQuotes()
+            => this.Compose("2001-12-15T02:59:43.1Z", "2001-12-15T02:59:43.1Z");
+
+        [Test]
+        public void GetYamlCompatibleString_DateTimeSpacedString_NotWrappedWithQuotes()
+            => this.Compose("2001-12-14 21:59:43.10 -5", "2001-12-14 21:59:43.10 -5");
+
+        [Test]
+        public void GetYamlCompatibleString_DateString_NotWrappedWithQuotes()
+            => this.Compose("2002-12-14", "2002-12-14");
 
         [Test]
         [TestCase("\0", "\\0")]

--- a/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Writers/SpecialCharacterStringExtensionsTests.cs
@@ -62,11 +62,11 @@ namespace LEGO.AsyncAPI.Tests.Writers
 
         [Test]
         public void GetYamlCompatibleString_DateTimeSlashString_WrappedWithQuotes()
-            => this.Compose("12/31/2022 23:59:59", "'12/31/2022 23:59:59'");
+            => this.Compose("12/31/2022 23:59:59", "12/31/2022 23:59:59");
 
         [Test]
         public void GetYamlCompatibleString_DateTimeDashString_WrappedWithQuotes()
-            => this.Compose("2022-12-31 23:59:59", "'2022-12-31 23:59:59'");
+            => this.Compose("2022-12-31 23:59:59", "2022-12-31 23:59:59");
 
         [Test]
         public void GetYamlCompatibleString_DateTimeISOString_NotWrappedWithQuotes()


### PR DESCRIPTION
## About the PR
The project currently targets .Net6.0 which there is no real reason to as this just limits the use case of this library. With this PR I have targeted all libraries to .netstandard2.0. 

A bunch of the unit tests were broken as well so I fixed them all up, as well as added more converged to the specific things that were breaking. 

### Changelog
- Changed to .netstandard2.0
- Fixed all broken unit tests 
- Added more unit tests. 


On an unrelated note, there is a **ton** of warnings about styling, should this not be disabled if they are just being ignored anyway? 
