### PR TITLE
chore: add TryGetValue extensions for bindings

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -4,7 +4,6 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
 {
     using System;
     using LEGO.AsyncAPI.Models;
-    using LEGO.AsyncAPI.Models.Bindings.Kafka;
     using LEGO.AsyncAPI.Readers.ParseNodes;
     using LEGO.AsyncAPI.Writers;
 

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/TopicConfigurationObject.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) The LEGO Group. All rights reserved.
 
-namespace LEGO.AsyncAPI.Models.Bindings.Kafka
+namespace LEGO.AsyncAPI.Bindings.Kafka
 {
     using System;
     using System.Collections.Generic;
+    using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Writers;
 

--- a/src/LEGO.AsyncAPI/Models/AsyncApiBindings.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiBindings.cs
@@ -7,6 +7,33 @@ namespace LEGO.AsyncAPI.Models
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Writers;
 
+    public static class BindingExtensions
+    {
+        public static bool TryGetValue<TBinding>(this AsyncApiBindings<IServerBinding> bindings, out IServerBinding binding)
+            where TBinding : IServerBinding
+        {
+            return bindings.TryGetValue(Activator.CreateInstance<TBinding>().BindingKey, out binding);
+        }
+
+        public static bool TryGetValue<TBinding>(this AsyncApiBindings<IChannelBinding> bindings, out IChannelBinding binding)
+    where TBinding : IChannelBinding
+        {
+            return bindings.TryGetValue(Activator.CreateInstance<TBinding>().BindingKey, out binding);
+        }
+
+        public static bool TryGetValue<TBinding>(this AsyncApiBindings<IOperationBinding> bindings, out IOperationBinding binding)
+    where TBinding : IOperationBinding
+        {
+            return bindings.TryGetValue(Activator.CreateInstance<TBinding>().BindingKey, out binding);
+        }
+
+        public static bool TryGetValue<TBinding>(this AsyncApiBindings<IMessageBinding> bindings, out IMessageBinding binding)
+    where TBinding : IMessageBinding
+        {
+            return bindings.TryGetValue(Activator.CreateInstance<TBinding>().BindingKey, out binding);
+        }
+    }
+
     public class AsyncApiBindings<TBinding> : Dictionary<string, TBinding>, IAsyncApiReferenceable
         where TBinding : IBinding
     {

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Kafka/KafkaBindings_Should.cs
@@ -2,14 +2,13 @@
 
 namespace LEGO.AsyncAPI.Tests.Bindings.Kafka
 {
+    using System.Collections.Generic;
     using FluentAssertions;
     using LEGO.AsyncAPI.Bindings;
     using LEGO.AsyncAPI.Bindings.Kafka;
     using LEGO.AsyncAPI.Models;
-    using LEGO.AsyncAPI.Models.Bindings.Kafka;
     using LEGO.AsyncAPI.Readers;
     using NUnit.Framework;
-    using System.Collections.Generic;
 
     internal class KafkaBindings_Should
     {


### PR DESCRIPTION
## About the PR
This PR adds extensions for the AsyncApiBindings dictionary, so fetching specific bindings becomes a lot easier.
So instead of having to do;
```csharp
server.bindings.TryGetValue("kafka", out var binding);
```
you can now do
```csharp
server.bindings.TryGetValue<KafkaServerBinding>(out var binding);
```

Yes it uses reflection.
### Changelog
- Added TryGetValue extensions.
- Fixed weird kafka namespace

### Related Issues
- Closes #<issue-number>
