### PR TITLE
fix: inline channel parameters should not deserialize as references

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,48 @@ var stream = await httpClient.GetStreamAsync("master/examples/streetlights-kafka
 var asyncApiDocument = new AsyncApiStreamReader().Read(stream, out var diagnostic);
 ```
 
+#### Reading External $ref
+
+You can read externally referenced AsyncAPI documents by setting the `ReferenceResolution` property of the `AsyncApiReaderSettings` object to `ReferenceResolutionSetting.ResolveAllReferences` and providing an implementation for the `IAsyncApiExternalReferenceReader` interface. This interface contains a single method to which the built AsyncAPI.NET reader library will pass the location content contained in a `$ref` property (usually some form of path) and interface will return the content which is retrieved from wherever the `$ref` points to as a `string`. The AsyncAPI.NET reader will then automatically infer the `T` type of the content and recursively parse the external content into an AsyncAPI document as a child of the original document that contained the `$ref`. This means that you can have externally referenced documents that themselves contain external references. 
+
+This interface allows users to load the content of their external reference however and from whereever is required. A new instance of the implementor of `IAsyncApiExternalReferenceReader` should be registered with the `ExternalReferenceReader` property of the `AsyncApiReaderSettings` when creating the reader from which the `GetExternalResource` method will be called when resolving external references.
+
+Below is a very simple example of implementation for `IAsyncApiExternalReferenceReader` that simply loads a file and returns it as a string found at the reference endpoint.
+```csharp
+using System.IO;
+
+public class AsyncApiExternalFileSystemReader : IAsyncApiExternalReferenceReader
+{
+    public string GetExternalResource(string reference)
+    {
+        return File.ReadAllText(reference);
+    }
+}
+```
+
+This can then be configured in the reader as follows:
+```csharp
+var settings = new AsyncApiReaderSettings
+{
+  ReferenceResolution = ReferenceResolutionSetting.ResolveAllReferences,
+  ExternalReferenceReader = new AsyncApiExternalFileSystemReader(),
+};
+var reader = new AsyncApiStringReader(settings);
+```
+
+This would function for a AsyncAPI document with following reference to load the content of `message.yaml` as a `AsyncApiMessage` object inline with the document object.
+```yaml
+asyncapi: 2.3.0
+info:
+  title: test
+  version: 1.0.0
+channels:
+  workspace:
+    publish:
+      message:
+        $ref: "../../../message.yaml"
+```
+
 ### Bindings
 To add support for reading bindings, simply add the bindings you wish to support, to the `Bindings` collection of `AsyncApiReaderSettings`.
 There is a nifty helper to add different types of bindings, or like in the example `All` of them.

--- a/src/LEGO.AsyncAPI.Bindings/Http/HttpMessageBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Http/HttpMessageBinding.cs
@@ -42,7 +42,7 @@ namespace LEGO.AsyncAPI.Bindings.Http
         protected override FixedFieldMap<HttpMessageBinding> FixedFieldMap => new()
         {
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
-            { "headers", (a, n) => { a.Headers = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "headers", (a, n) => { a.Headers = AsyncApiSchemaDeserializer.LoadSchema(n); } },
         };
     }
 }

--- a/src/LEGO.AsyncAPI.Bindings/Http/HttpOperationBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Http/HttpOperationBinding.cs
@@ -63,7 +63,7 @@ namespace LEGO.AsyncAPI.Bindings.Http
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
             { "type", (a, n) => { a.Type = n.GetScalarValue().GetEnumFromDisplayName<HttpOperationType>(); } },
             { "method", (a, n) => { a.Method = n.GetScalarValue(); } },
-            { "query", (a, n) => { a.Query = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "query", (a, n) => { a.Query = AsyncApiSchemaDeserializer.LoadSchema(n); } },
         };
 
         public override string BindingKey => "http";

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaMessageBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaMessageBinding.cs
@@ -67,7 +67,7 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         protected override FixedFieldMap<KafkaMessageBinding> FixedFieldMap => new()
         {
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
-            { "key", (a, n) => { a.Key = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "key", (a, n) => { a.Key = AsyncApiSchemaDeserializer.LoadSchema(n); } },
             { "schemaIdLocation", (a, n) => { a.SchemaIdLocation = n.GetScalarValue(); } },
             { "schemaIdPayloadEncoding", (a, n) => { a.SchemaIdPayloadEncoding = n.GetScalarValue(); } },
             { "schemaLookupStrategy", (a, n) => { a.SchemaLookupStrategy = n.GetScalarValue(); } },

--- a/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaOperationBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Kafka/KafkaOperationBinding.cs
@@ -28,8 +28,8 @@ namespace LEGO.AsyncAPI.Bindings.Kafka
         protected override FixedFieldMap<KafkaOperationBinding> FixedFieldMap => new()
         {
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
-            { "groupId", (a, n) => { a.GroupId = JsonSchemaDeserializer.LoadSchema(n); } },
-            { "clientId", (a, n) => { a.ClientId = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "groupId", (a, n) => { a.GroupId = AsyncApiSchemaDeserializer.LoadSchema(n); } },
+            { "clientId", (a, n) => { a.ClientId = AsyncApiSchemaDeserializer.LoadSchema(n); } },
         };
 
         /// <summary>

--- a/src/LEGO.AsyncAPI.Bindings/MQTT/MQTTMessageBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/MQTT/MQTTMessageBinding.cs
@@ -57,7 +57,7 @@ namespace LEGO.AsyncAPI.Bindings.MQTT
         protected override FixedFieldMap<MQTTMessageBinding> FixedFieldMap => new()
         {
             { "payloadFormatIndicator", (a, n) => { a.PayloadFormatIndicator = n.GetIntegerValueOrDefault(); } },
-            { "correlationData", (a, n) => { a.CorrelationData = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "correlationData", (a, n) => { a.CorrelationData = AsyncApiSchemaDeserializer.LoadSchema(n); } },
             { "contentType", (a, n) => { a.ContentType = n.GetScalarValue(); } },
             { "responseTopic", (a, n) => { a.ResponseTopic = n.GetScalarValue(); } },
         };

--- a/src/LEGO.AsyncAPI.Bindings/WebSockets/WebSocketsChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/WebSockets/WebSocketsChannelBinding.cs
@@ -31,8 +31,8 @@ namespace LEGO.AsyncAPI.Bindings.WebSockets
         {
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
             { "method", (a, n) => { a.Method = n.GetScalarValue(); } },
-            { "query", (a, n) => { a.Query = JsonSchemaDeserializer.LoadSchema(n); } },
-            { "headers", (a, n) => { a.Headers = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "query", (a, n) => { a.Query = AsyncApiSchemaDeserializer.LoadSchema(n); } },
+            { "headers", (a, n) => { a.Headers = AsyncApiSchemaDeserializer.LoadSchema(n); } },
         };
 
         public override void SerializeProperties(IAsyncApiWriter writer)

--- a/src/LEGO.AsyncAPI.Readers/AsyncApiExternalReferenceResolver.cs
+++ b/src/LEGO.AsyncAPI.Readers/AsyncApiExternalReferenceResolver.cs
@@ -91,7 +91,10 @@ namespace LEGO.AsyncAPI.Readers
         public override void Visit(AsyncApiMessage message)
         {
             this.ResolveObject(message.Headers, r => message.Headers = r);
-            this.ResolveObject(message.Payload, r => message.Payload = r);
+            if (message.Payload is AsyncApiSchemaPayload)
+            {
+                this.ResolveObject(message.Payload as AsyncApiSchemaPayload, r => message.Payload = r);
+            }
             this.ResolveList(message.Traits);
             this.ResolveObject(message.CorrelationId, r => message.CorrelationId = r);
             this.ResolveObject(message.Bindings, r => message.Bindings = r);

--- a/src/LEGO.AsyncAPI.Readers/AsyncApiJsonDocumentReader.cs
+++ b/src/LEGO.AsyncAPI.Readers/AsyncApiJsonDocumentReader.cs
@@ -1,5 +1,7 @@
 // Copyright (c) The LEGO Group. All rights reserved.
 
+using System;
+
 namespace LEGO.AsyncAPI.Readers
 {
     using System.Collections.Generic;
@@ -12,6 +14,7 @@ namespace LEGO.AsyncAPI.Readers
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
     using LEGO.AsyncAPI.Readers.Interface;
+    using LEGO.AsyncAPI.Services;
     using LEGO.AsyncAPI.Validations;
 
     /// <summary>
@@ -165,22 +168,47 @@ namespace LEGO.AsyncAPI.Readers
 
         private void ResolveReferences(AsyncApiDiagnostic diagnostic, AsyncApiDocument document)
         {
-            var errors = new List<AsyncApiError>();
-
-            // Resolve References if requested
             switch (this.settings.ReferenceResolution)
             {
-                case ReferenceResolutionSetting.ResolveReferences:
-                    errors.AddRange(document.ResolveReferences());
+                case ReferenceResolutionSetting.ResolveAllReferences:
+                    this.ResolveAllReferences(diagnostic, document);
                     break;
-
+                case ReferenceResolutionSetting.ResolveInternalReferences:
+                    this.ResolveInternalReferences(diagnostic, document);
+                    break;
                 case ReferenceResolutionSetting.DoNotResolveReferences:
                     break;
             }
+        }
+
+        private void ResolveAllReferences(AsyncApiDiagnostic diagnostic, AsyncApiDocument document)
+        {
+            this.ResolveInternalReferences(diagnostic, document);
+            this.ResolveExternalReferences(diagnostic, document);
+        }
+
+        private void ResolveInternalReferences(AsyncApiDiagnostic diagnostic, AsyncApiDocument document)
+        {
+            var errors = new List<AsyncApiError>();
+
+            var reader = new AsyncApiStringReader(this.settings);
+            errors.AddRange(document.ResolveReferences());
 
             foreach (var item in errors)
             {
                 diagnostic.Errors.Add(item);
+            }
+        }
+
+        private void ResolveExternalReferences(AsyncApiDiagnostic diagnostic, AsyncApiDocument document)
+        {
+            var resolver = new AsyncApiExternalReferenceResolver(document, this.settings);
+            var walker = new AsyncApiWalker(resolver);
+            walker.Walk(document);
+
+            foreach (var error in resolver.Errors)
+            {
+                diagnostic.Errors.Add(error);
             }
         }
     }

--- a/src/LEGO.AsyncAPI.Readers/AsyncApiReaderSettings.cs
+++ b/src/LEGO.AsyncAPI.Readers/AsyncApiReaderSettings.cs
@@ -18,9 +18,14 @@ namespace LEGO.AsyncAPI.Readers
         DoNotResolveReferences,
 
         /// <summary>
-        /// Resolve internal component references and inline them.
+        /// Resolve all references and inline them.
         /// </summary>
-        ResolveReferences,
+        ResolveInternalReferences,
+
+        /// <summary>
+        /// Resolve internal component references and inline them while leaving external references as placeholder objects with an AsyncApiReference instance and UnresolvedReference set to true.
+        /// </summary>
+        ResolveAllReferences,
     }
 
     /// <summary>
@@ -32,7 +37,7 @@ namespace LEGO.AsyncAPI.Readers
         /// Indicates how references in the source document should be handled.
         /// </summary>
         public ReferenceResolutionSetting ReferenceResolution { get; set; } =
-            ReferenceResolutionSetting.ResolveReferences;
+            ReferenceResolutionSetting.ResolveInternalReferences;
 
         /// <summary>
         /// Dictionary of parsers for converting extensions into strongly typed classes.
@@ -57,5 +62,10 @@ namespace LEGO.AsyncAPI.Readers
         /// from an <see cref="AsyncApiStreamReader"/> object.
         /// </summary>
         public bool LeaveStreamOpen { get; set; }
+
+        /// <summary>
+        /// External reference reader implementation provided by users for reading external resources.
+        /// </summary>
+        public IAsyncApiExternalReferenceReader ExternalReferenceReader { get; set; }
     }
 }

--- a/src/LEGO.AsyncAPI.Readers/Interface/IAsyncApiExternalReferenceReader.cs
+++ b/src/LEGO.AsyncAPI.Readers/Interface/IAsyncApiExternalReferenceReader.cs
@@ -1,0 +1,14 @@
+namespace LEGO.AsyncAPI.Readers;
+
+/// <summary>
+/// Interface that provides method for reading external references.å
+/// </summary>
+public interface IAsyncApiExternalReferenceReader
+{
+    /// <summary>
+    /// Method that returns the AsyncAPI content that the external reference from the $ref points to.
+    /// </summary>
+    /// <param name="reference">The content address of the $ref.</param>
+    /// <returns>The content of the reference as a string.</returns>
+    public string Load(string reference);
+}

--- a/src/LEGO.AsyncAPI.Readers/ParseNodes/PropertyNode.cs
+++ b/src/LEGO.AsyncAPI.Readers/ParseNodes/PropertyNode.cs
@@ -79,7 +79,7 @@ namespace LEGO.AsyncAPI.Readers.ParseNodes
                 else
                 {
                     this.Context.Diagnostic.Errors.Add(
-                        new AsyncApiError("", $"{this.Name} is not a valid property at {this.Context.GetLocation()}"));
+                        new AsyncApiError(string.Empty, $"{this.Name} is not a valid property at {this.Context.GetLocation()}"));
                 }
             }
         }

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiChannelDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiChannelDeserializer.cs
@@ -14,7 +14,7 @@ namespace LEGO.AsyncAPI.Readers
             { "servers", (a, n) => { a.Servers = n.CreateSimpleList(s => s.GetScalarValue()); } },
             { "subscribe", (a, n) => { a.Subscribe = LoadOperation(n); } },
             { "publish", (a, n) => { a.Publish = LoadOperation(n); } },
-            { "parameters", (a, n) => { a.Parameters = n.CreateMapWithReference(ReferenceType.Parameter, LoadParameter); } },
+            { "parameters", (a, n) => { a.Parameters = n.CreateMap(LoadParameter); } },
             { "bindings", (a, n) => { a.Bindings = LoadChannelBindings(n); } },
         };
 

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiComponentsDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiComponentsDeserializer.cs
@@ -10,7 +10,7 @@ namespace LEGO.AsyncAPI.Readers
     {
         private static FixedFieldMap<AsyncApiComponents> componentsFixedFields = new()
         {
-            { "schemas", (a, n) => a.Schemas = n.CreateMapWithReference(ReferenceType.Schema, JsonSchemaDeserializer.LoadSchema) },
+            { "schemas", (a, n) => a.Schemas = n.CreateMapWithReference(ReferenceType.Schema, AsyncApiSchemaDeserializer.LoadSchema) },
             { "servers", (a, n) => a.Servers = n.CreateMapWithReference(ReferenceType.Server, LoadServer) },
             { "channels", (a, n) => a.Channels = n.CreateMapWithReference(ReferenceType.Channel, LoadChannel) },
             { "messages", (a, n) => a.Messages = n.CreateMapWithReference(ReferenceType.Message, LoadMessage) },

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiMessageTraitDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiMessageTraitDeserializer.cs
@@ -11,7 +11,7 @@ namespace LEGO.AsyncAPI.Readers
         private static FixedFieldMap<AsyncApiMessageTrait> messageTraitFixedFields = new()
         {
             { "messageId", (a, n) => { a.MessageId = n.GetScalarValue(); } },
-            { "headers", (a, n) => { a.Headers = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "headers", (a, n) => { a.Headers = AsyncApiSchemaDeserializer.LoadSchema(n); } },
             { "correlationId", (a, n) => { a.CorrelationId = LoadCorrelationId(n); } },
             { "schemaFormat", (a, n) => { a.SchemaFormat = n.GetScalarValue(); } },
             { "contentType", (a, n) => { a.ContentType = n.GetScalarValue(); } },

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiParameterDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiParameterDeserializer.cs
@@ -11,7 +11,7 @@ namespace LEGO.AsyncAPI.Readers
         private static FixedFieldMap<AsyncApiParameter> parameterFixedFields = new()
         {
             { "description", (a, n) => { a.Description = n.GetScalarValue(); } },
-            { "schema", (a, n) => { a.Schema = JsonSchemaDeserializer.LoadSchema(n); } },
+            { "schema", (a, n) => { a.Schema = AsyncApiSchemaDeserializer.LoadSchema(n); } },
             { "location", (a, n) => { a.Location = n.GetScalarValue(); } },
         };
 

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiSchemaDeserializer.cs
@@ -9,7 +9,7 @@ namespace LEGO.AsyncAPI.Readers
     using LEGO.AsyncAPI.Readers.ParseNodes;
     using LEGO.AsyncAPI.Writers;
 
-    public class JsonSchemaDeserializer
+    public class AsyncApiSchemaDeserializer
     {
         private static readonly FixedFieldMap<AsyncApiSchema> schemaFixedFields = new()
         {

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiV2VersionService.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiV2VersionService.cs
@@ -35,7 +35,8 @@ namespace LEGO.AsyncAPI.Readers.V2
             [typeof(AsyncApiOAuthFlows)] = AsyncApiV2Deserializer.LoadOAuthFlows,
             [typeof(AsyncApiOperation)] = AsyncApiV2Deserializer.LoadOperation,
             [typeof(AsyncApiParameter)] = AsyncApiV2Deserializer.LoadParameter,
-            [typeof(AsyncApiSchema)] = JsonSchemaDeserializer.LoadSchema,
+            [typeof(AsyncApiSchema)] = AsyncApiSchemaDeserializer.LoadSchema,
+            [typeof(AsyncApiSchemaPayload)] = AsyncApiV2Deserializer.LoadPayload, // #ToFix how do we get the schemaFormat?!
             [typeof(AsyncApiSecurityRequirement)] = AsyncApiV2Deserializer.LoadSecurityRequirement,
             [typeof(AsyncApiSecurityScheme)] = AsyncApiV2Deserializer.LoadSecurityScheme,
             [typeof(AsyncApiServer)] = AsyncApiV2Deserializer.LoadServer,

--- a/src/LEGO.AsyncAPI/Models/AsyncApiAvroSchemaPayload.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiAvroSchemaPayload.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Models
+{
+    using System;
+    using LEGO.AsyncAPI.Models.Interfaces;
+    using LEGO.AsyncAPI.Writers;
+
+    public class AsyncApiAvroSchemaPayload : IAsyncApiMessagePayload
+    {
+        public void SerializeV2(IAsyncApiWriter writer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/LEGO.AsyncAPI/Models/AsyncApiMessage.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiMessage.cs
@@ -25,7 +25,7 @@ namespace LEGO.AsyncAPI.Models
         /// <summary>
         /// definition of the message payload. It can be of any type but defaults to Schema object. It must match the schema format, including encoding type - e.g Avro should be inlined as either a YAML or JSON object NOT a string to be parsed as YAML or JSON.
         /// </summary>
-        public AsyncApiSchema Payload { get; set; }
+        public IAsyncApiMessagePayload Payload { get; set; }
 
         /// <summary>
         /// definition of the correlation ID used for message tracing or matching.

--- a/src/LEGO.AsyncAPI/Models/AsyncApiSchemaPayload.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiSchemaPayload.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Models
+{
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+    using LEGO.AsyncAPI.Models.Interfaces;
+    using LEGO.AsyncAPI.Writers;
+
+    public class AsyncApiSchemaPayload : IAsyncApiMessagePayload, IAsyncApiReferenceable
+    {
+        private readonly AsyncApiSchema schema;
+
+        public AsyncApiSchemaPayload()
+        {
+            this.schema = new AsyncApiSchema();
+        }
+
+        public AsyncApiSchemaPayload(AsyncApiSchema schema)
+        {
+            this.schema = schema;
+        }
+
+        public string Title { get => this.schema.Title; set => this.schema.Title = value; }
+
+        public SchemaType? Type { get => this.schema.Type; set => this.schema.Type = value; }
+
+        public string Format { get => this.schema.Format; set => this.schema.Format = value; }
+
+        public string Description { get => this.schema.Description; set => this.schema.Description = value; }
+
+        public double? Maximum { get => this.schema.Maximum; set => this.schema.Maximum = value; }
+
+        public bool? ExclusiveMaximum { get => this.schema.ExclusiveMaximum; set => this.schema.ExclusiveMaximum = value; }
+
+        public double? Minimum { get => this.schema.Minimum; set => this.schema.Minimum = value; }
+
+        public bool? ExclusiveMinimum { get => this.schema.ExclusiveMinimum; set => this.schema.ExclusiveMinimum = value; }
+
+        public int? MaxLength { get => this.schema.MaxLength; set => this.schema.MaxLength = value; }
+
+        public int? MinLength { get => this.schema.MinLength; set => this.schema.MinLength = value; }
+
+        public string Pattern { get => this.schema.Pattern; set => this.schema.Pattern = value; }
+
+        public double? MultipleOf { get => this.schema.MultipleOf; set => this.schema.MultipleOf = value; }
+
+        public AsyncApiAny Default { get => this.schema.Default; set => this.schema.Default = value; }
+
+        public bool ReadOnly { get => this.schema.ReadOnly; set => this.schema.ReadOnly = value; }
+
+        public bool WriteOnly { get => this.schema.WriteOnly; set => this.schema.WriteOnly = value; }
+
+        public IList<AsyncApiSchema> AllOf { get => this.schema.AllOf; set => this.schema.AllOf = value; }
+
+        public IList<AsyncApiSchema> OneOf { get => this.schema.OneOf; set => this.schema.OneOf = value; }
+
+        public IList<AsyncApiSchema> AnyOf { get => this.schema.AnyOf; set => this.schema.AnyOf = value; }
+
+        public AsyncApiSchema Not { get => this.schema.Not; set => this.schema.Not = value; }
+
+        public AsyncApiSchema Contains { get => this.schema.Contains; set => this.schema.Contains = value; }
+
+        public AsyncApiSchema If { get => this.schema.If; set => this.schema.If = value; }
+
+        public AsyncApiSchema Then { get => this.schema.Then; set => this.schema.Then = value; }
+
+        public AsyncApiSchema Else { get => this.schema.Else; set => this.schema.Else = value; }
+
+        public ISet<string> Required { get => this.schema.Required; set => this.schema.Required = value; }
+
+        public AsyncApiSchema Items { get => this.schema.Items; set => this.schema.Items = value; }
+
+        public AsyncApiSchema AdditionalItems { get => this.schema.AdditionalItems; set => this.schema.AdditionalItems = value; }
+
+        public int? MaxItems { get => this.schema.MaxItems; set => this.schema.MaxItems = value; }
+
+        public int? MinItems { get => this.schema.MinItems; set => this.schema.MinItems = value; }
+
+        public bool? UniqueItems { get => this.schema.UniqueItems; set => this.schema.UniqueItems = value; }
+
+        public IDictionary<string, AsyncApiSchema> Properties { get => this.schema.Properties; set => this.schema.Properties = value; }
+
+        public int? MaxProperties { get => this.schema.MaxProperties; set => this.schema.MaxProperties = value; }
+
+        public int? MinProperties { get => this.schema.MinProperties; set => this.schema.MinProperties = value; }
+
+        public IDictionary<string, AsyncApiSchema> PatternProperties { get => this.schema.PatternProperties; set => this.schema.PatternProperties = value; }
+
+        public AsyncApiSchema PropertyNames { get => this.schema.PropertyNames; set => this.schema.PropertyNames = value; }
+
+        public string Discriminator { get => this.schema.Discriminator; set => this.schema.Discriminator = value; }
+
+        public IList<AsyncApiAny> Enum { get => this.schema.Enum; set => this.schema.Enum = value; }
+
+        public IList<AsyncApiAny> Examples { get => this.schema.Examples; set => this.schema.Examples = value; }
+
+        public AsyncApiAny Const { get => this.schema.Const; set => this.schema.Const = value; }
+
+        public bool Nullable { get => this.schema.Nullable; set => this.schema.Nullable = value; }
+
+        public AsyncApiExternalDocumentation ExternalDocs { get => this.schema.ExternalDocs; set => this.schema.ExternalDocs = value; }
+
+        public bool Deprecated { get => this.schema.Deprecated; set => this.schema.Deprecated = value; }
+
+        public bool UnresolvedReference { get => this.schema.UnresolvedReference; set => this.schema.UnresolvedReference = value; }
+
+        public AsyncApiReference Reference { get => this.schema.Reference; set => this.schema.Reference = value; }
+
+        public IDictionary<string, IAsyncApiExtension> Extensions { get => this.schema.Extensions; set => this.schema.Extensions = value; }
+
+        public AsyncApiSchema AdditionalProperties { get => this.schema.AdditionalProperties; set => this.schema.AdditionalProperties = value; }
+
+        public static implicit operator AsyncApiSchema(AsyncApiSchemaPayload payload) => payload.schema;
+
+        public static implicit operator AsyncApiSchemaPayload(AsyncApiSchema schema) => new AsyncApiSchemaPayload(schema);
+
+        public void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.schema.SerializeV2(writer);
+        }
+
+        public void SerializeV2WithoutReference(IAsyncApiWriter writer)
+        {
+            this.schema.SerializeV2WithoutReference(writer);
+        }
+    }
+}

--- a/src/LEGO.AsyncAPI/Models/Interfaces/IAsyncApiPayload.cs
+++ b/src/LEGO.AsyncAPI/Models/Interfaces/IAsyncApiPayload.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Models.Interfaces
+{
+    public interface IAsyncApiMessagePayload : IAsyncApiSerializable
+    {
+    }
+}

--- a/src/LEGO.AsyncAPI/Services/AsyncApiReferenceResolver.cs
+++ b/src/LEGO.AsyncAPI/Services/AsyncApiReferenceResolver.cs
@@ -86,7 +86,11 @@ namespace LEGO.AsyncAPI.Services
         public override void Visit(AsyncApiMessage message)
         {
             this.ResolveObject(message.Headers, r => message.Headers = r);
-            this.ResolveObject(message.Payload, r => message.Payload = r);
+            // #ToFix Resolve references correctly 
+            if (message.Payload is AsyncApiSchemaPayload)
+            {
+                this.ResolveObject(message.Payload as AsyncApiSchemaPayload, r => message.Payload = r);
+            }
             this.ResolveList(message.Traits);
             this.ResolveObject(message.CorrelationId, r => message.CorrelationId = r);
             this.ResolveObject(message.Bindings, r => message.Bindings = r);

--- a/src/LEGO.AsyncAPI/Services/AsyncApiWalker.cs
+++ b/src/LEGO.AsyncAPI/Services/AsyncApiWalker.cs
@@ -501,7 +501,11 @@ namespace LEGO.AsyncAPI.Services
             if (message != null)
             {
                 this.Walk(AsyncApiConstants.Headers, () => this.Walk(message.Headers));
-                this.Walk(AsyncApiConstants.Payload, () => this.Walk(message.Payload));
+                if (message.Payload is AsyncApiSchemaPayload payload)
+                {
+                    this.Walk(AsyncApiConstants.Payload, () => this.Walk((AsyncApiSchema)payload));
+                }
+                // #ToFix Add walking for avro.
                 this.Walk(AsyncApiConstants.CorrelationId, () => this.Walk(message.CorrelationId));
                 this.Walk(AsyncApiConstants.Tags, () => this.Walk(message.Tags));
                 this.Walk(AsyncApiConstants.Examples, () => this.Walk(message.Examples));

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -493,7 +493,7 @@ namespace LEGO.AsyncAPI.Tests
                         },
                     },
                     },
-                    Payload = new AsyncApiSchema()
+                    Payload = new AsyncApiSchemaPayload
                     {
                         Reference = new AsyncApiReference()
                         {
@@ -518,7 +518,7 @@ namespace LEGO.AsyncAPI.Tests
                         },
                     },
                     },
-                    Payload = new AsyncApiSchema()
+                    Payload = new AsyncApiSchemaPayload()
                     {
                         Reference = new AsyncApiReference()
                         {
@@ -543,7 +543,7 @@ namespace LEGO.AsyncAPI.Tests
                         },
                     },
                     },
-                    Payload = new AsyncApiSchema()
+                    Payload = new AsyncApiSchemaPayload()
                     {
                         Reference = new AsyncApiReference()
                         {

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiChannel_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiChannel_Should.cs
@@ -3,15 +3,36 @@
 namespace LEGO.AsyncAPI.Tests.Models
 {
     using System.Collections.Generic;
+    using System.Linq;
     using FluentAssertions;
     using LEGO.AsyncAPI.Bindings.Kafka;
     using LEGO.AsyncAPI.Bindings.WebSockets;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
+    using LEGO.AsyncAPI.Readers;
     using NUnit.Framework;
 
     internal class AsyncApiChannel_Should : TestBase
     {
+        [Test]
+        public void AsyncApiChannel_WithInlineParameter_DoesNotCreateReference()
+        {
+            var input =
+                """
+                    parameters:
+                      id:
+                        description: ids
+                        schema:
+                          type: string
+                          enum:
+                            - 08735ae0-6a1a-4578-8b4a-35aa26d15993
+                            - 97845c62-329c-4d87-ad24-4f611b909a10
+                """;
+
+            var channel = new AsyncApiStringReader().ReadFragment<AsyncApiChannel>(input, AsyncApiVersion.AsyncApi2_0, out var _ );
+            channel.Parameters.First().Value.Reference.Should().BeNull();
+        }
+
         [Test]
         public void AsyncApiChannel_WithWebSocketsBinding_Serializes()
         {

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiMessage_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiMessage_Should.cs
@@ -41,7 +41,7 @@ namespace LEGO.AsyncAPI.Tests.Models
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            message.Payload.Properties.First().Value.Enum.Should().HaveCount(2);
+            message.Payload.As<AsyncApiSchemaPayload>().Properties.First().Value.Enum.Should().HaveCount(2);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace LEGO.AsyncAPI.Tests.Models
                       type:
                         - 'null'
                         - string
-                schemaFormat: application/vnd.apache.avro;version=1.9.0
+                schemaFormat: whatever
                 """;
 
             // Act
@@ -86,7 +86,7 @@ namespace LEGO.AsyncAPI.Tests.Models
 
             // Assert
             diagnostic.Errors.Should().HaveCount(1);
-            diagnostic.Errors.First().Message.Should().StartWith("'application/vnd.apache.avro;version=1.9.0' is not a supported format");
+            diagnostic.Errors.First().Message.Should().StartWith("'whatever' is not a supported format");
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace LEGO.AsyncAPI.Tests.Models
                 """;
 
             var message = new AsyncApiMessage();
-            message.Payload = new AsyncApiSchema()
+            message.Payload = new AsyncApiSchemaPayload()
             {
                 Properties = new Dictionary<string, AsyncApiSchema>()
                 {
@@ -119,7 +119,6 @@ namespace LEGO.AsyncAPI.Tests.Models
 
             // Act
             var actual = message.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
-
 
             var deserializedMessage = new AsyncApiStringReader().ReadFragment<AsyncApiMessage>(expected, AsyncApiVersion.AsyncApi2_0, out _);
 
@@ -146,7 +145,7 @@ namespace LEGO.AsyncAPI.Tests.Models
 
             var message = new AsyncApiMessage();
             message.SchemaFormat = "application/vnd.aai.asyncapi+json;version=2.6.0";
-            message.Payload = new AsyncApiSchema()
+            message.Payload = new AsyncApiSchemaPayload()
             {
                 Properties = new Dictionary<string, AsyncApiSchema>()
                 {
@@ -257,7 +256,7 @@ namespace LEGO.AsyncAPI.Tests.Models
                         }),
                     },
                 },
-                Payload = new AsyncApiSchema()
+                Payload = new AsyncApiSchemaPayload()
                 {
                     Properties = new Dictionary<string, AsyncApiSchema>
                     {

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiReference_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiReference_Should.cs
@@ -26,9 +26,10 @@ namespace LEGO.AsyncAPI.Tests
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            deserialized.Payload.UnresolvedReference.Should().BeTrue();
+            var payload = deserialized.Payload.As<AsyncApiSchemaPayload>();
+            payload.UnresolvedReference.Should().BeTrue();
 
-            var reference = deserialized.Payload.Reference;
+            var reference = payload.Reference;
             reference.ExternalResource.Should().Be("http://example.com/some-resource");
             reference.Id.Should().Be("/path/to/external/fragment");
             reference.IsFragment.Should().BeTrue();
@@ -54,9 +55,10 @@ namespace LEGO.AsyncAPI.Tests
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            deserialized.Payload.UnresolvedReference.Should().BeTrue();
+            var payload = deserialized.Payload.As<AsyncApiSchemaPayload>();
+            payload.UnresolvedReference.Should().BeTrue();
 
-            var reference = deserialized.Payload.Reference;
+            var reference = payload.Reference;
             reference.Type.Should().Be(ReferenceType.Schema);
             reference.ExternalResource.Should().Be("/fragments/myFragment");
             reference.Id.Should().BeNull();
@@ -82,7 +84,8 @@ namespace LEGO.AsyncAPI.Tests
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            var reference = deserialized.Payload.Reference;
+            var payload = deserialized.Payload.As<AsyncApiSchemaPayload>();
+            var reference = payload.Reference;
             reference.ExternalResource.Should().BeNull();
             reference.Type.Should().Be(ReferenceType.Schema);
             reference.Id.Should().Be("test");
@@ -109,7 +112,8 @@ namespace LEGO.AsyncAPI.Tests
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            var reference = deserialized.Payload.Reference;
+            var payload = deserialized.Payload.As<AsyncApiSchemaPayload>();
+            var reference = payload.Reference;
             reference.ExternalResource.Should().Be("./myjsonfile.json");
             reference.Id.Should().Be("/fragment");
             reference.IsFragment.Should().BeTrue();
@@ -135,7 +139,8 @@ namespace LEGO.AsyncAPI.Tests
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            var reference = deserialized.Payload.Reference;
+            var payload = deserialized.Payload.As<AsyncApiSchemaPayload>();
+            var reference = payload.Reference;
             reference.ExternalResource.Should().Be("./someotherdocument.json");
             reference.Type.Should().Be(ReferenceType.Schema);
             reference.Id.Should().Be("test");
@@ -268,7 +273,8 @@ namespace LEGO.AsyncAPI.Tests
 
             // Assert
             diagnostic.Errors.Should().BeEmpty();
-            var reference = deserialized.Payload.Reference;
+            var payload = deserialized.Payload.As<AsyncApiSchemaPayload>();
+            var reference = payload.Reference;
             reference.ExternalResource.Should().Be("http://example.com/json.json");
             reference.Id.Should().BeNull();
             reference.IsExternal.Should().BeTrue();
@@ -305,7 +311,8 @@ namespace LEGO.AsyncAPI.Tests
             var doc = reader.Read(yaml, out var diagnostic);
             var message = doc.Channels["workspace"].Publish.Message.First();
             message.Name.Should().Be("Test");
-            message.Payload.Properties.Count.Should().Be(3);
+            var payload = message.Payload.As<AsyncApiSchemaPayload>();
+            payload.Properties.Count.Should().Be(3);
         }
     }
 

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiSchema_Should.cs
@@ -421,7 +421,7 @@ namespace LEGO.AsyncAPI.Tests.Models
                     {
                         new AsyncApiMessage
                         {
-                            Payload = new AsyncApiSchema
+                            Payload = new AsyncApiSchemaPayload
                             {
                                 Type = SchemaType.Object,
                                 Required = new HashSet<string> { "testB" },


### PR DESCRIPTION
## About the PR
The deserializer was creating a `CreateMapWithReference`, causing the deserialized model to have a reference.
When re-serializing, the parameter was serialized as a reference, but without the component efter existing.

`CreateMapWithReference` should never have been used here.
### Changelog
- Added: regression test
- Changed: `CreateMapWithReference` to `CreateMap` for parameters in the channel deserializer.
