### PR TITLE
fix: inline channel parameters should not deserialize as references

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiChannelDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiChannelDeserializer.cs
@@ -14,7 +14,7 @@ namespace LEGO.AsyncAPI.Readers
             { "servers", (a, n) => { a.Servers = n.CreateSimpleList(s => s.GetScalarValue()); } },
             { "subscribe", (a, n) => { a.Subscribe = LoadOperation(n); } },
             { "publish", (a, n) => { a.Publish = LoadOperation(n); } },
-            { "parameters", (a, n) => { a.Parameters = n.CreateMapWithReference(ReferenceType.Parameter, LoadParameter); } },
+            { "parameters", (a, n) => { a.Parameters = n.CreateMap(LoadParameter); } },
             { "bindings", (a, n) => { a.Bindings = LoadChannelBindings(n); } },
         };
 

--- a/test/LEGO.AsyncAPI.Tests/Models/AsyncApiChannel_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AsyncApiChannel_Should.cs
@@ -3,15 +3,36 @@
 namespace LEGO.AsyncAPI.Tests.Models
 {
     using System.Collections.Generic;
+    using System.Linq;
     using FluentAssertions;
     using LEGO.AsyncAPI.Bindings.Kafka;
     using LEGO.AsyncAPI.Bindings.WebSockets;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
+    using LEGO.AsyncAPI.Readers;
     using NUnit.Framework;
 
     internal class AsyncApiChannel_Should : TestBase
     {
+        [Test]
+        public void AsyncApiChannel_WithInlineParameter_DoesNotCreateReference()
+        {
+            var input =
+                """
+                    parameters:
+                      id:
+                        description: ids
+                        schema:
+                          type: string
+                          enum:
+                            - 08735ae0-6a1a-4578-8b4a-35aa26d15993
+                            - 97845c62-329c-4d87-ad24-4f611b909a10
+                """;
+
+            var channel = new AsyncApiStringReader().ReadFragment<AsyncApiChannel>(input, AsyncApiVersion.AsyncApi2_0, out var _ );
+            channel.Parameters.First().Value.Reference.Should().BeNull();
+        }
+
         [Test]
         public void AsyncApiChannel_WithWebSocketsBinding_Serializes()
         {


### PR DESCRIPTION
## About the PR
The deserializer was creating a `CreateMapWithReference`, causing the deserialized model to have a reference.
When re-serializing, the parameter was serialized as a reference, but without the component efter existing.

`CreateMapWithReference` should never have been used here.
### Changelog
- Added: regression test
- Changed: `CreateMapWithReference` to `CreateMap` for parameters in the channel deserializer.