### PR TITLE
feat: unmapped member handling during deserialization

### DIFF
--- a/src/LEGO.AsyncAPI.Readers/AsyncApiReaderSettings.cs
+++ b/src/LEGO.AsyncAPI.Readers/AsyncApiReaderSettings.cs
@@ -40,6 +40,12 @@ namespace LEGO.AsyncAPI.Readers
             ReferenceResolutionSetting.ResolveInternalReferences;
 
         /// <summary>
+        /// Indicates what should happen when unmapped members are encountered during deserialization.
+        /// Error and Warning will add an error or warning to the diagnostics object.
+        /// </summary>
+        public UnmappedMemberHandling UnmappedMemberHandling { get; set; } = UnmappedMemberHandling.Error;
+
+        /// <summary>
         /// Dictionary of parsers for converting extensions into strongly typed classes.
         /// </summary>
         public Dictionary<string, Func<AsyncApiAny, IAsyncApiExtension>>

--- a/src/LEGO.AsyncAPI.Readers/ParseNodes/PropertyNode.cs
+++ b/src/LEGO.AsyncAPI.Readers/ParseNodes/PropertyNode.cs
@@ -29,8 +29,7 @@ namespace LEGO.AsyncAPI.Readers.ParseNodes
             IDictionary<string, Action<T, ParseNode>> fixedFields,
             IDictionary<Func<string, bool>, Action<T, string, ParseNode>> patternFields)
         {
-            var found = fixedFields.TryGetValue(this.Name, out var fixedFieldMap);
-
+            var _ = fixedFields.TryGetValue(this.Name, out var fixedFieldMap);
             if (fixedFieldMap != null)
             {
                 try
@@ -78,8 +77,12 @@ namespace LEGO.AsyncAPI.Readers.ParseNodes
                 }
                 else
                 {
-                    this.Context.Diagnostic.Errors.Add(
-                        new AsyncApiError(string.Empty, $"{this.Name} is not a valid property at {this.Context.GetLocation()}"));
+                    switch (this.Context.Settings.UnmappedMemberHandling)
+                    {
+                        case UnmappedMemberHandling.Error:
+                            this.Context.Diagnostic.Errors.Add(new AsyncApiError(string.Empty, $"{this.Name} is not a valid property at {this.Context.GetLocation()}"));
+                            break;
+                    }
                 }
             }
         }

--- a/src/LEGO.AsyncAPI.Readers/UnmappedMemberHandling.cs
+++ b/src/LEGO.AsyncAPI.Readers/UnmappedMemberHandling.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Readers
+{
+    /// <summary>
+    /// Unmapped member handling.
+    /// </summary>
+    public enum UnmappedMemberHandling
+    {
+        /// <summary>
+        /// Add error to diagnostics for unmapped members.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Ignore unmapped members.
+        /// </summary>
+        Ignore,
+    }
+}

--- a/src/LEGO.AsyncAPI.Readers/V2/AsyncApiAvroSchemaDeserializer.cs
+++ b/src/LEGO.AsyncAPI.Readers/V2/AsyncApiAvroSchemaDeserializer.cs
@@ -3,6 +3,7 @@
 namespace LEGO.AsyncAPI.Readers
 {
     using System;
+    using LEGO.AsyncAPI.Exceptions;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Readers.Exceptions;
     using LEGO.AsyncAPI.Readers.ParseNodes;
@@ -169,7 +170,7 @@ namespace LEGO.AsyncAPI.Readers
                         mapNode.ParseFields(ref union, UnionFixedFields, UnionMetadataPatternFields);
                         return union;
                     default:
-                        throw new InvalidOperationException($"Unsupported type: {type}");
+                        throw new AsyncApiException($"Unsupported type: {type}");
                 }
             }
 

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiReaderTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiReaderTests.cs
@@ -5,6 +5,7 @@ namespace LEGO.AsyncAPI.Tests
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using FluentAssertions;
     using LEGO.AsyncAPI.Exceptions;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
@@ -30,6 +31,7 @@ namespace LEGO.AsyncAPI.Tests
                 info:
                   title: test
                   version: 1.0.0
+                  test: 1234
                   contact:  
                     name: API Support
                     url: https://www.example.com/support
@@ -57,11 +59,102 @@ namespace LEGO.AsyncAPI.Tests
                 {
                     { extensionName, valueExtensionParser },
                 },
+                UnmappedMemberHandling = UnmappedMemberHandling.Ignore,
             };
 
             var reader = new AsyncApiStringReader(settings);
             var doc = reader.Read(yaml, out var diagnostic);
             Assert.AreEqual((doc.Channels["workspace"].Extensions[extensionName] as AsyncApiAny).GetValue<int>(), 1234);
+        }
+
+        [Test]
+        public void Read_WithUnmappedMemberHandlingError_AddsError()
+        {
+            var extensionName = "x-someValue";
+            var yaml = $"""
+        asyncapi: 2.3.0
+        info:
+          title: test
+          version: 1.0.0
+          test: 1234
+          contact:  
+            name: API Support
+            url: https://www.example.com/support
+            email: support@example.com
+        channels:
+          workspace:
+            {extensionName}: onetwothreefour
+        """;
+            Func<AsyncApiAny, IAsyncApiExtension> valueExtensionParser = (any) =>
+            {
+                if (any.TryGetValue<string>(out var value))
+                {
+                    if (value == "onetwothreefour")
+                    {
+                        return new AsyncApiAny(1234);
+                    }
+                }
+
+                return new AsyncApiAny("No value provided");
+            };
+
+            var settings = new AsyncApiReaderSettings
+            {
+                ExtensionParsers = new Dictionary<string, Func<AsyncApiAny, IAsyncApiExtension>>
+        {
+            { extensionName, valueExtensionParser },
+        },
+                UnmappedMemberHandling = UnmappedMemberHandling.Error,
+            };
+
+            var reader = new AsyncApiStringReader(settings);
+            var doc = reader.Read(yaml, out var diagnostic);
+            diagnostic.Errors.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void Read_WithUnmappedMemberHandlingIgnore_NoErrors()
+        {
+            var extensionName = "x-someValue";
+            var yaml = $"""
+        asyncapi: 2.3.0
+        info:
+          title: test
+          version: 1.0.0
+          test: 1234
+          contact:  
+            name: API Support
+            url: https://www.example.com/support
+            email: support@example.com
+        channels:
+          workspace:
+            {extensionName}: onetwothreefour
+        """;
+            Func<AsyncApiAny, IAsyncApiExtension> valueExtensionParser = (any) =>
+            {
+                if (any.TryGetValue<string>(out var value))
+                {
+                    if (value == "onetwothreefour")
+                    {
+                        return new AsyncApiAny(1234);
+                    }
+                }
+
+                return new AsyncApiAny("No value provided");
+            };
+
+            var settings = new AsyncApiReaderSettings
+            {
+                ExtensionParsers = new Dictionary<string, Func<AsyncApiAny, IAsyncApiExtension>>
+            {
+                { extensionName, valueExtensionParser },
+            },
+                UnmappedMemberHandling = UnmappedMemberHandling.Ignore,
+            };
+
+            var reader = new AsyncApiStringReader(settings);
+            var doc = reader.Read(yaml, out var diagnostic);
+            diagnostic.Errors.Should().HaveCount(0);
         }
 
         [Test]


### PR DESCRIPTION
## About the PR
Added unmapped memberhandling so you can stop errors from appearing in the diagnostics, if you have unmapped members.

### Changelog
- Add: unmapped member handling enum
### Related Issues
- Closes #169
