### PR TITLE
fix: resolving wrong reference

### DIFF
--- a/src/LEGO.AsyncAPI/Services/AsyncApiReferenceResolver.cs
+++ b/src/LEGO.AsyncAPI/Services/AsyncApiReferenceResolver.cs
@@ -218,7 +218,13 @@ namespace LEGO.AsyncAPI.Services
 
             try
             {
-                return this.currentDocument.ResolveReference(reference) as T;
+                var resolvedReference = this.currentDocument.ResolveReference(reference) as T;
+                if (resolvedReference == null)
+                {
+                    throw new AsyncApiException($"Cannot resolve reference '{reference.Reference}' to '{typeof(T).Name}'.");
+                }
+
+                return resolvedReference;
             }
             catch (AsyncApiException ex)
             {


### PR DESCRIPTION
## About the PR
When a reference is resolved, that doesnt map to the correct type, for instance;
```yaml
asyncapi: 2.3.0
info:
  title: test
  version: 1.0.0
channels:
  workspace:
    publish:
      message:
        $ref: '#/components/securitySchemes/saslScram'
components:
  securitySchemes:
    saslScram:
      type: scramSha256
      description: Provide your username and password for SASL/SCRAM authentication
```
mapping a message to a securityScheme. No error will be present in the diagnostics object.
The message will simply be null. 

This PR adds a quick and dirty exception to reference resolution when casting to `T` ends with being null.
