### PR TITLE
chore: make principal values public

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalObject.cs
@@ -6,7 +6,7 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalObject : Principal
 {
-    private KeyValuePair<string, StringOrStringList> PrincipalValue;
+    public KeyValuePair<string, StringOrStringList> PrincipalValue;
 
     public PrincipalObject(KeyValuePair<string, StringOrStringList> principalValue)
     {

--- a/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalObject.cs
@@ -6,11 +6,11 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalObject : Principal
 {
-    public KeyValuePair<string, StringOrStringList> PrincipalValue;
+    public KeyValuePair<string, StringOrStringList> Value { get; private set; }
 
-    public PrincipalObject(KeyValuePair<string, StringOrStringList> principalValue)
+    public PrincipalObject(KeyValuePair<string, StringOrStringList> value)
     {
-        this.PrincipalValue = principalValue;
+        this.Value = value;
     }
 
     public override void Serialize(IAsyncApiWriter writer)
@@ -21,7 +21,7 @@ public class PrincipalObject : Principal
         }
 
         writer.WriteStartObject();
-        writer.WriteRequiredObject(this.PrincipalValue.Key, this.PrincipalValue.Value, (w, t) => t.Value.Write(w));
+        writer.WriteRequiredObject(this.Value.Key, this.Value.Value, (w, t) => t.Value.Write(w));
         writer.WriteEndObject();
     }
 }

--- a/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalStar.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalStar.cs
@@ -5,7 +5,7 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalStar : Principal
 {
-    private string PrincipalValue;
+    public string PrincipalValue;
 
     public PrincipalStar()
     {

--- a/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalStar.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/PrincipalStar.cs
@@ -5,11 +5,11 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalStar : Principal
 {
-    public string PrincipalValue;
+    public string Value { get; private set; }
 
     public PrincipalStar()
     {
-        this.PrincipalValue = "*";
+        this.Value = "*";
     }
 
     public override void Serialize(IAsyncApiWriter writer)
@@ -19,6 +19,6 @@ public class PrincipalStar : Principal
             throw new ArgumentNullException(nameof(writer));
         }
 
-        writer.WriteValue(this.PrincipalValue);
+        writer.WriteValue(this.Value);
     }
 }

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalObject.cs
@@ -6,7 +6,7 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalObject : Principal
 {
-    private KeyValuePair<string, StringOrStringList> PrincipalValue;
+    public KeyValuePair<string, StringOrStringList> PrincipalValue;
 
     public PrincipalObject(KeyValuePair<string, StringOrStringList> principalValue)
     {

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalObject.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalObject.cs
@@ -6,11 +6,11 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalObject : Principal
 {
-    public KeyValuePair<string, StringOrStringList> PrincipalValue;
+    public KeyValuePair<string, StringOrStringList> Value { get; private set; }
 
-    public PrincipalObject(KeyValuePair<string, StringOrStringList> principalValue)
+    public PrincipalObject(KeyValuePair<string, StringOrStringList> value)
     {
-        this.PrincipalValue = principalValue;
+        this.Value = value;
     }
 
     public override void Serialize(IAsyncApiWriter writer)
@@ -21,7 +21,7 @@ public class PrincipalObject : Principal
         }
 
         writer.WriteStartObject();
-        writer.WriteRequiredObject(this.PrincipalValue.Key, this.PrincipalValue.Value, (w, t) => t.Value.Write(w));
+        writer.WriteRequiredObject(this.Value.Key, this.Value.Value, (w, t) => t.Value.Write(w));
         writer.WriteEndObject();
     }
 }

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalStar.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalStar.cs
@@ -5,7 +5,7 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalStar : Principal
 {
-    private string PrincipalValue;
+    public string PrincipalValue;
 
     public PrincipalStar()
     {

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalStar.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/PrincipalStar.cs
@@ -5,11 +5,11 @@ using LEGO.AsyncAPI.Writers;
 
 public class PrincipalStar : Principal
 {
-    public string PrincipalValue;
+    public string Value { get; private set; }
 
     public PrincipalStar()
     {
-        this.PrincipalValue = "*";
+        this.Value = "*";
     }
 
     public override void Serialize(IAsyncApiWriter writer)
@@ -19,6 +19,6 @@ public class PrincipalStar : Principal
             throw new ArgumentNullException(nameof(writer));
         }
 
-        writer.WriteValue(this.PrincipalValue);
+        writer.WriteValue(this.Value);
     }
 }


### PR DESCRIPTION
## About the PR

https://github.com/LEGO/AsyncAPI.NET/pull/187 was recently merged, however, the principal value properties were set as private. This was a mistake and should be made public so that they can be used after the asyncapi specs have been processed.

### Changelog
- Add: AWS Policy Prinicpal values made public
