### PR TITLE
chore: make aws condition value explicit

### DIFF
--- a/src/LEGO.AsyncAPI.Bindings/Sns/Condition.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/Condition.cs
@@ -1,0 +1,67 @@
+// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Bindings.Sns;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LEGO.AsyncAPI.Models.Interfaces;
+using LEGO.AsyncAPI.Readers.ParseNodes;
+using LEGO.AsyncAPI.Writers;
+
+public class Condition : IAsyncApiElement
+{
+    public Dictionary<string, Dictionary<string, StringOrStringList>> Value { get; private set; }
+
+    public Condition(Dictionary<string, Dictionary<string, StringOrStringList>> value)
+    {
+        this.Value = value;
+    }
+
+    public void Serialize(IAsyncApiWriter writer)
+    {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        writer.WriteStartObject();
+        foreach (var conditionValue in this.Value)
+        {
+            writer.WriteRequiredMap(conditionValue.Key, conditionValue.Value, (w, t) => t.Value.Write(w));
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public static Condition Parse(ParseNode node)
+    {
+        switch (node)
+        {
+            case MapNode mapNode:
+            {
+                var conditionValues = new Dictionary<string, Dictionary<string, StringOrStringList>>();
+                foreach (var conditionNode in mapNode)
+                {
+                    switch (conditionNode.Value)
+                    {
+                        case MapNode conditionValueNode:
+                            conditionValues.Add(conditionNode.Name, new Dictionary<string, StringOrStringList>(conditionValueNode.Select(x =>
+                                    new KeyValuePair<string, StringOrStringList>(x.Name, StringOrStringList.Parse(x.Value)))
+                                .ToDictionary(x => x.Key, x => x.Value)));
+                            break;
+                        default:
+                            throw new ArgumentException($"An error occured while parsing a {nameof(Condition)} node. " +
+                                                        $"AWS condition values should be one or more key value pairs.");
+                    }
+                }
+
+                return new Condition(conditionValues);
+            }
+
+            default:
+                throw new ArgumentException($"An error occured while parsing a {nameof(Condition)} node. " +
+                                            $"Node should contain a collection of condition types.");
+        }
+    }
+}

--- a/src/LEGO.AsyncAPI.Bindings/Sns/SnsChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/SnsChannelBinding.cs
@@ -60,7 +60,7 @@ namespace LEGO.AsyncAPI.Bindings.Sns
             { "principal", (a, n) => { a.Principal = Principal.Parse(n); } },
             { "action", (a, n) => { a.Action = StringOrStringList.Parse(n); } },
             { "resource", (a, n) => { a.Resource = StringOrStringList.Parse(n); } },
-            { "condition", (a, n) => { a.Condition = n.CreateAny(); } },
+            { "condition", (a, n) => { a.Condition = Condition.Parse(n); } },
         };
 
         /// <inheritdoc/>

--- a/src/LEGO.AsyncAPI.Bindings/Sns/Statement.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/Statement.cs
@@ -33,7 +33,7 @@ namespace LEGO.AsyncAPI.Bindings.Sns
         /// <summary>
         /// Specific circumstances under which the policy grants permission.
         /// </summary>
-        public AsyncApiAny? Condition { get; set; }
+        public Condition? Condition { get; set; }
 
         public IDictionary<string, IAsyncApiExtension> Extensions { get; set; } = new Dictionary<string, IAsyncApiExtension>();
 
@@ -49,7 +49,7 @@ namespace LEGO.AsyncAPI.Bindings.Sns
             writer.WriteRequiredObject("principal", this.Principal, (w, t) => t.Serialize(w));
             writer.WriteRequiredObject("action", this.Action, (w, t) => t.Value.Write(w));
             writer.WriteOptionalObject("resource", this.Resource, (w, t) => t?.Value.Write(w));
-            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t?.Write(w));
+            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t?.Serialize(w));
             writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }

--- a/src/LEGO.AsyncAPI.Bindings/Sns/Statement.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sns/Statement.cs
@@ -33,7 +33,7 @@ namespace LEGO.AsyncAPI.Bindings.Sns
         /// <summary>
         /// Specific circumstances under which the policy grants permission.
         /// </summary>
-        public Condition? Condition { get; set; }
+        public Condition Condition { get; set; }
 
         public IDictionary<string, IAsyncApiExtension> Extensions { get; set; } = new Dictionary<string, IAsyncApiExtension>();
 
@@ -49,7 +49,7 @@ namespace LEGO.AsyncAPI.Bindings.Sns
             writer.WriteRequiredObject("principal", this.Principal, (w, t) => t.Serialize(w));
             writer.WriteRequiredObject("action", this.Action, (w, t) => t.Value.Write(w));
             writer.WriteOptionalObject("resource", this.Resource, (w, t) => t?.Value.Write(w));
-            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t?.Serialize(w));
+            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t.Serialize(w));
             writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/Condition.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/Condition.cs
@@ -1,0 +1,67 @@
+// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Bindings.Sqs;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LEGO.AsyncAPI.Models.Interfaces;
+using LEGO.AsyncAPI.Readers.ParseNodes;
+using LEGO.AsyncAPI.Writers;
+
+public class Condition : IAsyncApiElement
+{
+    public Dictionary<string, Dictionary<string, StringOrStringList>> Value { get; private set; }
+
+    public Condition(Dictionary<string, Dictionary<string, StringOrStringList>> value)
+    {
+        this.Value = value;
+    }
+
+    public void Serialize(IAsyncApiWriter writer)
+    {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        writer.WriteStartObject();
+        foreach (var conditionValue in this.Value)
+        {
+            writer.WriteRequiredMap(conditionValue.Key, conditionValue.Value, (w, t) => t.Value.Write(w));
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public static Condition Parse(ParseNode node)
+    {
+        switch (node)
+        {
+            case MapNode mapNode:
+            {
+                var conditionValues = new Dictionary<string, Dictionary<string, StringOrStringList>>();
+                foreach (var conditionNode in mapNode)
+                {
+                    switch (conditionNode.Value)
+                    {
+                        case MapNode conditionValueNode:
+                            conditionValues.Add(conditionNode.Name, new Dictionary<string, StringOrStringList>(conditionValueNode.Select(x =>
+                                    new KeyValuePair<string, StringOrStringList>(x.Name, StringOrStringList.Parse(x.Value)))
+                                .ToDictionary(x => x.Key, x => x.Value)));
+                            break;
+                        default:
+                            throw new ArgumentException($"An error occured while parsing a {nameof(Condition)} node. " +
+                                                        $"AWS condition values should be one or more key value pairs.");
+                    }
+                }
+
+                return new Condition(conditionValues);
+            }
+
+            default:
+                throw new ArgumentException($"An error occured while parsing a {nameof(Condition)} node. " +
+                                            $"Node should contain a collection of AWS condition types.");
+        }
+    }
+}

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/SqsChannelBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/SqsChannelBinding.cs
@@ -67,7 +67,7 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
             { "principal", (a, n) => { a.Principal = Principal.Parse(n); } },
             { "action", (a, n) => { a.Action = StringOrStringList.Parse(n); } },
             { "resource", (a, n) => { a.Resource = StringOrStringList.Parse(n); } },
-            { "condition", (a, n) => { a.Condition = n.CreateAny(); } },
+            { "condition", (a, n) => { a.Condition = Condition.Parse(n); } },
         };
 
         public override void SerializeProperties(IAsyncApiWriter writer)

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/SqsOperationBinding.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/SqsOperationBinding.cs
@@ -59,7 +59,7 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
             { "principal", (a, n) => { a.Principal = Principal.Parse(n); } },
             { "action", (a, n) => { a.Action = StringOrStringList.Parse(n); } },
             { "resource", (a, n) => { a.Resource = StringOrStringList.Parse(n); } },
-            { "condition", (a, n) => { a.Condition = n.CreateAny(); } },
+            { "condition", (a, n) => { a.Condition = Condition.Parse(n); } },
         };
 
         public override void SerializeProperties(IAsyncApiWriter writer)

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/Statement.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/Statement.cs
@@ -34,7 +34,7 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
         /// <summary>
         /// Specific circumstances under which the policy grants permission.
         /// </summary>
-        public AsyncApiAny? Condition { get; set; }
+        public Condition? Condition { get; set; }
 
         public IDictionary<string, IAsyncApiExtension> Extensions { get; set; } = new Dictionary<string, IAsyncApiExtension>();
 
@@ -50,7 +50,7 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
             writer.WriteRequiredObject("principal", this.Principal, (w, t) => t.Serialize(w));
             writer.WriteRequiredObject("action", this.Action, (w, t) => t.Value.Write(w));
             writer.WriteOptionalObject("resource", this.Resource, (w, t) => t?.Value.Write(w));
-            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t?.Write(w));
+            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t?.Serialize(w));
             writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }

--- a/src/LEGO.AsyncAPI.Bindings/Sqs/Statement.cs
+++ b/src/LEGO.AsyncAPI.Bindings/Sqs/Statement.cs
@@ -34,7 +34,7 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
         /// <summary>
         /// Specific circumstances under which the policy grants permission.
         /// </summary>
-        public Condition? Condition { get; set; }
+        public Condition Condition { get; set; }
 
         public IDictionary<string, IAsyncApiExtension> Extensions { get; set; } = new Dictionary<string, IAsyncApiExtension>();
 
@@ -50,7 +50,7 @@ namespace LEGO.AsyncAPI.Bindings.Sqs
             writer.WriteRequiredObject("principal", this.Principal, (w, t) => t.Serialize(w));
             writer.WriteRequiredObject("action", this.Action, (w, t) => t.Value.Write(w));
             writer.WriteOptionalObject("resource", this.Resource, (w, t) => t?.Value.Write(w));
-            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t?.Serialize(w));
+            writer.WriteOptionalObject("condition", this.Condition, (w, t) => t.Serialize(w));
             writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sns/SnsBindings_Should.cs
@@ -92,12 +92,14 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
                                 "sns:Publish",
                                 "sns:Delete",
                             })),
-                            Condition = new AsyncApiAny(new Dictionary<string, object>()
+                            Condition = new Condition(new Dictionary<string, Dictionary<string, StringOrStringList>>
                             {
                                 {
-                                    "StringEquals", new Dictionary<string, List<string>>()
+                                    "StringEquals", new Dictionary<string, StringOrStringList>
                                     {
-                                        { "aws:username", new List<string>() { "johndoe", "mrsmith" } },
+                                        {
+                                            "aws:username", new StringOrStringList(new AsyncApiAny(new List<string>() { "johndoe", "mrsmith" }))
+                                        },
                                     }
                                 },
                             }),
@@ -109,12 +111,14 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sns
                                 "AWS", new StringOrStringList(new AsyncApiAny(new List<string>
                                     { "arn:aws:iam::123456789012:user/alex.wichmann", "arn:aws:iam::123456789012:user/dec.kolakowski" })))),
                             Action = new StringOrStringList(new AsyncApiAny("sns:Create")),
-                            Condition = new AsyncApiAny(new Dictionary<string, object>()
+                            Condition = new Condition(new Dictionary<string, Dictionary<string, StringOrStringList>>
                             {
                                 {
-                                    "NumericLessThanEquals", new Dictionary<string, string>()
+                                    "NumericLessThanEquals", new Dictionary<string, StringOrStringList>
                                     {
-                                        { "aws:MultiFactorAuthAge", "3600" },
+                                        {
+                                            "aws:MultiFactorAuthAge", new StringOrStringList(new AsyncApiAny("3600"))
+                                        },
                                     }
                                 },
                             }),

--- a/test/LEGO.AsyncAPI.Tests/Bindings/Sqs/SqsBindings_should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Bindings/Sqs/SqsBindings_should.cs
@@ -143,12 +143,14 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
                                     "sqs:SendMessage",
                                     "sqs:ReceiveMessage",
                                 })),
-                                Condition = new AsyncApiAny(new Dictionary<string, object>()
+                                Condition = new Condition(new Dictionary<string, Dictionary<string, StringOrStringList>>
                                 {
                                     {
-                                        "StringEquals", new Dictionary<string, List<string>>()
+                                        "StringEquals", new Dictionary<string, StringOrStringList>
                                         {
-                                            { "aws:username", new List<string>() { "johndoe", "mrsmith" } },
+                                            {
+                                                "aws:username", new StringOrStringList(new AsyncApiAny(new List<string> { "johndoe", "mrsmith" }))
+                                            },
                                         }
                                     },
                                 }),
@@ -170,12 +172,14 @@ namespace LEGO.AsyncAPI.Tests.Bindings.Sqs
                                     "AWS", new StringOrStringList(new AsyncApiAny(new List<string>
                                         { "arn:aws:iam::123456789012:user/alex.wichmann", "arn:aws:iam::123456789012:user/dec.kolakowski" })))),
                                 Action = new StringOrStringList(new AsyncApiAny("sqs:CreateQueue")),
-                                Condition = new AsyncApiAny(new Dictionary<string, object>()
+                                Condition = new Condition(new Dictionary<string, Dictionary<string, StringOrStringList>>
                                 {
                                     {
-                                        "NumericLessThanEquals", new Dictionary<string, string>()
+                                        "NumericLessThanEquals", new Dictionary<string, StringOrStringList>
                                         {
-                                            { "aws:MultiFactorAuthAge", "3600" },
+                                            {
+                                                "aws:MultiFactorAuthAge", new StringOrStringList(new AsyncApiAny("3600"))
+                                            },
                                         }
                                     },
                                 }),


### PR DESCRIPTION
## About the PR
The value of the AWS condition is currently set to AsyncApiAny. This is too open-ended and makes it difficult for the user to parse and use the value when parsing AsyncApi files. This PR sets the structure for `condition` and makes it explicit, which will make using the value on the other side more simple.

### Changelog
- Update: Set an explicit value for AWS condition

### Related Issues
N/A
