### PR TITLE
chore: add AvroValidationRule for names and symbols

### DIFF
--- a/src/LEGO.AsyncAPI/Resource.Designer.cs
+++ b/src/LEGO.AsyncAPI/Resource.Designer.cs
@@ -104,5 +104,23 @@ namespace LEGO.AsyncAPI {
                 return ResourceManager.GetString("Validation_MustBeAbsoluteUrl", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos;  MUST match the regular expression &apos;{1}&apos;..
+        /// </summary>
+        internal static string Validation_NameMustMatchRegularExpr {
+            get {
+                return ResourceManager.GetString("Validation_NameMustMatchRegularExpr", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Symbols  MUST match the regular expression &apos;{1}&apos;..
+        /// </summary>
+        internal static string Validation_SymbolsMustMatchRegularExpression {
+            get {
+                return ResourceManager.GetString("Validation_SymbolsMustMatchRegularExpression", resourceCulture);
+            }
+        }
     }
 }

--- a/src/LEGO.AsyncAPI/Resource.resx
+++ b/src/LEGO.AsyncAPI/Resource.resx
@@ -132,4 +132,10 @@
   <data name="Validation_MustBeAbsoluteUrl" xml:space="preserve">
     <value>The field '{0}' in '{1}' object MUST be an absolute uri.</value>
   </data>
+  <data name="Validation_NameMustMatchRegularExpr" xml:space="preserve">
+    <value>'{0}'  MUST match the regular expression '{1}'.</value>
+  </data>
+  <data name="Validation_SymbolsMustMatchRegularExpression" xml:space="preserve">
+    <value>Symbols  MUST match the regular expression '{1}'.</value>
+  </data>
 </root>

--- a/src/LEGO.AsyncAPI/Services/AsyncApiVisitorBase.cs
+++ b/src/LEGO.AsyncAPI/Services/AsyncApiVisitorBase.cs
@@ -55,6 +55,14 @@ namespace LEGO.AsyncAPI.Services
         {
         }
 
+        public virtual void Visit(AsyncApiJsonSchemaPayload jsonPayload)
+        {
+        }
+
+        public virtual void Visit(AsyncApiAvroSchemaPayload avroPayload)
+        {
+        }
+
         public virtual void Visit(IDictionary<string, AsyncApiAny> anys)
         {
         }

--- a/src/LEGO.AsyncAPI/Services/AsyncApiWalker.cs
+++ b/src/LEGO.AsyncAPI/Services/AsyncApiWalker.cs
@@ -326,6 +326,11 @@ namespace LEGO.AsyncAPI.Services
             this.Walk(parameter as IAsyncApiExtensible);
         }
 
+        internal void Walk(AsyncApiAvroSchemaPayload payload)
+        {
+            this.visitor.Visit(payload);
+        }
+
         internal void Walk(AsyncApiSchema schema, bool isComponent = false)
         {
             if (schema == null || this.ProcessAsReference(schema, isComponent))
@@ -539,7 +544,11 @@ namespace LEGO.AsyncAPI.Services
                     this.Walk(AsyncApiConstants.Payload, () => this.Walk((AsyncApiSchema)payload));
                 }
 
-                // #ToFix Add walking for avro.
+                if (message.Payload is AsyncApiAvroSchemaPayload avroPayload)
+                {
+                    this.Walk(AsyncApiConstants.Payload, () => this.Walk(avroPayload));
+                }
+
                 this.Walk(AsyncApiConstants.CorrelationId, () => this.Walk(message.CorrelationId));
                 this.Walk(AsyncApiConstants.Tags, () => this.Walk(message.Tags));
                 this.Walk(AsyncApiConstants.Examples, () => this.Walk(message.Examples));

--- a/src/LEGO.AsyncAPI/Validation/AsyncApiValidator.cs
+++ b/src/LEGO.AsyncAPI/Validation/AsyncApiValidator.cs
@@ -144,6 +144,10 @@ namespace LEGO.AsyncAPI.Validations
 
         public override void Visit(IMessageBinding item) => this.Validate(item);
 
+        public override void Visit(AsyncApiAvroSchemaPayload item) => this.Validate(item);
+
+        public override void Visit(AsyncApiJsonSchemaPayload item) => this.Validate(item);
+
         /// <summary>
         /// Execute validation rules against an <see cref="IAsyncApiExtensible"/>.
         /// </summary>

--- a/src/LEGO.AsyncAPI/Validation/Rules/AsyncApiAvroRules.cs
+++ b/src/LEGO.AsyncAPI/Validation/Rules/AsyncApiAvroRules.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) The LEGO Group. All rights reserved.
+
+namespace LEGO.AsyncAPI.Validation.Rules
+{
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using LEGO.AsyncAPI.Models;
+    using LEGO.AsyncAPI.Validations;
+
+    [AsyncApiRule]
+    public static class AsyncApiAvroRules
+    {
+        /// <summary>
+        /// The key regex.
+        /// </summary>
+        public static Regex NameRegex = new Regex(@"^[A-Za-z_][A-Za-z0-9_]*$");
+
+        public static ValidationRule<AsyncApiAvroSchemaPayload> NameRegularExpression =>
+            new ValidationRule<AsyncApiAvroSchemaPayload>(
+                (context, avroPayload) =>
+                {
+                    string name = null;
+                    context.Enter("name");
+                    if (avroPayload.TryGetAs<AvroRecord>(out var record))
+                    {
+                        name = record.Name;
+                    }
+
+                    if (avroPayload.TryGetAs<AvroEnum>(out var @enum))
+                    {
+                        name = @enum.Name;
+                        if (@enum.Symbols.Any(symbol => !NameRegex.IsMatch(symbol)))
+                        {
+                            context.CreateError(
+                                "SymbolsRegularExpression",
+                                string.Format(Resource.Validation_SymbolsMustMatchRegularExpression, NameRegex.ToString()));
+                        }
+                    }
+
+                    if (avroPayload.TryGetAs<AvroFixed>(out var @fixed))
+                    {
+                        name = @fixed.Name;
+                    }
+
+                    if (name == null)
+                    {
+                        return;
+                    }
+
+                    if (!NameRegex.IsMatch(record.Name))
+                    {
+                        context.CreateError(
+                            nameof(NameRegex),
+                            string.Format(Resource.Validation_NameMustMatchRegularExpr, name, NameRegex.ToString()));
+                    }
+
+                    context.Exit();
+                });
+    }
+}

--- a/test/LEGO.AsyncAPI.Tests/Validation/ValidationRulesetTests.cs
+++ b/test/LEGO.AsyncAPI.Tests/Validation/ValidationRulesetTests.cs
@@ -35,7 +35,7 @@ namespace LEGO.AsyncAPI.Tests.Validation
             Assert.IsNotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.AreEqual(17, rules.Count);
+            Assert.AreEqual(18, rules.Count);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `LEGO.AsyncAPI` project, primarily focusing on enhancing validation capabilities and adding support for Avro schema payloads. The most important changes include adding new validation rules, updating resource strings, and extending the visitor and walker functionalities.

### Validation Enhancements:
* Added new validation rules for `AsyncApiAvroSchemaPayload` to ensure names and symbols match specified regular expressions. (`src/LEGO.AsyncAPI/Validation/Rules/AsyncApiAvroRules.cs`)
* Introduced new resource strings for validation messages related to name and symbol regular expressions. (`src/LEGO.AsyncAPI/Resource.Designer.cs`, `src/LEGO.AsyncAPI/Resource.resx`) [[1]](diffhunk://#diff-1e9bb7d71db7e47579d02dbae6421aa98195dfcc4e08c2056a0361fec91fb9a8R107-R124) [[2]](diffhunk://#diff-cda9f8a3fd7560c5f3e9e39b467b79448af0ae5c0bf66c9e36dbbd72a7203323R135-R140)

### Visitor and Walker Extensions:
* Added `Visit` methods for `AsyncApiJsonSchemaPayload` and `AsyncApiAvroSchemaPayload` in `AsyncApiVisitorBase`. (`src/LEGO.AsyncAPI/Services/AsyncApiVisitorBase.cs`)
* Extended the `AsyncApiWalker` to handle `AsyncApiAvroSchemaPayload`. (`src/LEGO.AsyncAPI/Services/AsyncApiWalker.cs`) [[1]](diffhunk://#diff-97755249d132615b298a91ee4bc1663eff7d24c7bf316db53d4ce6a0b7a899faR329-R333) [[2]](diffhunk://#diff-97755249d132615b298a91ee4bc1663eff7d24c7bf316db53d4ce6a0b7a899faL542-R551)

### Validation Integration:
* Updated `AsyncApiValidator` to include validation for `AsyncApiAvroSchemaPayload` and `AsyncApiJsonSchemaPayload`. (`src/LEGO.AsyncAPI/Validation/AsyncApiValidator.cs`)