### PR TITLE
fix: null representation for AvroField 'default' property

### DIFF
--- a/src/LEGO.AsyncAPI/Models/Avro/AvroField.cs
+++ b/src/LEGO.AsyncAPI/Models/Avro/AvroField.cs
@@ -67,7 +67,18 @@ namespace LEGO.AsyncAPI.Models
             writer.WriteOptionalProperty("name", this.Name);
             writer.WriteOptionalObject("type", this.Type, (w, s) => s.SerializeV2(w));
             writer.WriteOptionalProperty("doc", this.Doc);
-            writer.WriteOptionalObject("default", this.Default, (w, s) => w.WriteAny(s));
+            writer.WriteOptionalObject("default", this.Default, (w, s) =>
+            {
+                if (s.TryGetValue(out string value) && value == "null")
+                {
+                    w.WriteNull();
+                }
+                else
+                {
+                    w.WriteAny(s);
+                }
+            });
+
             if (this.Order != AvroFieldOrder.None)
             {
                 writer.WriteOptionalProperty("order", this.Order.GetDisplayName());

--- a/test/LEGO.AsyncAPI.Tests/Models/AvroSchema_Should.cs
+++ b/test/LEGO.AsyncAPI.Tests/Models/AvroSchema_Should.cs
@@ -11,6 +11,29 @@ namespace LEGO.AsyncAPI.Tests.Models
     public class AvroSchema_Should
     {
         [Test]
+        public void Serialize_WithDefaultNull_SetJsonNull()
+        {
+            var input = """
+            type: record
+            name: User
+            namespace: Producer
+            doc: ESP Schema validation test
+            fields:
+              - name: userId
+                type: int
+              - name: userEmail
+                type:
+                  - null
+                  - string
+                default: null
+            """;
+
+            var model = new AsyncApiStringReader().ReadFragment<AvroSchema>(input, AsyncApiVersion.AsyncApi2_0, out var diag);
+            var reserialized = model.SerializeAsJson(AsyncApiVersion.AsyncApi2_0);
+            reserialized.Should().Contain("default\": null");
+        }
+
+        [Test]
         public void Deserialize_WithMetadata_CreatesMetadata()
         {
             var input =


### PR DESCRIPTION
This pull request includes changes to the `SerializeV2` method in `AvroField.cs` and adds a new test case in `AvroSchema_Should.cs` to handle serialization of default null values correctly.

### Handling default null values in serialization:

* [`src/LEGO.AsyncAPI/Models/Avro/AvroField.cs`](diffhunk://#diff-31d7a5e316924f57f061587f7de5f03e2b30f729e66e0b3876ac57f292d34547L70-R81): Modified the `SerializeV2` method to check if the default value is "null" and write a JSON null value accordingly.

### Adding a test case for serialization:

* [`test/LEGO.AsyncAPI.Tests/Models/AvroSchema_Should.cs`](diffhunk://#diff-b6070ee9357cf3afda4b2e29278939aca7ff8d59f78b67c2786ccdfb43b5c630R13-R35): Added a new test case `Serialize_WithDefaultNull_SetJsonNull` to verify that the default null value is correctly serialized as JSON null.