### PR TITLE
chore: upgrade from net6 to net8

### DIFF
--- a/Common.Build.props
+++ b/Common.Build.props
@@ -2,7 +2,7 @@
   <!-- Common Properties used by all assemblies -->
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Company>The LEGO Group</Company>
     <PackageProjectUrl>https://github.com/LEGO/AsyncAPI.NET</PackageProjectUrl>

--- a/src/LEGO.AsyncAPI.Bindings/LEGO.AsyncAPI.Bindings.csproj
+++ b/src/LEGO.AsyncAPI.Bindings/LEGO.AsyncAPI.Bindings.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LEGO.AsyncAPI.Readers/LEGO.AsyncAPI.Readers.csproj
+++ b/src/LEGO.AsyncAPI.Readers/LEGO.AsyncAPI.Readers.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj
+++ b/src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
 
 	  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 		  <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>


### PR DESCRIPTION
This pull request includes several updates to the project dependencies and target frameworks. The most important changes are the upgrade of the target framework to `net8` and the update of the `System.Text.Json` package version across multiple project files.

### Dependency and framework updates:

* [`Common.Build.props`](diffhunk://#diff-2915b440681d4b8a0f29292651453ec6dbfd3d5e46dc482682f55a814ca449f4L5-R5): Updated the `TargetFrameworks` property from `net6` to `net8`.
* [`src/LEGO.AsyncAPI.Bindings/LEGO.AsyncAPI.Bindings.csproj`](diffhunk://#diff-4ee188a81c8350bfa0d31467798dde56d83ead20806f1569dcd37c867a48e1c0R22): Added a new package reference for `System.Text.Json` version `9.0.1`.
* [`src/LEGO.AsyncAPI.Readers/LEGO.AsyncAPI.Readers.csproj`](diffhunk://#diff-052111eb4fc428ea5fa4582a88101b69dfb4cd2ef024828b8e1998ef2f673353R24): Added a new package reference for `System.Text.Json` version `9.0.1`.
* [`src/LEGO.AsyncAPI/LEGO.AsyncAPI.csproj`](diffhunk://#diff-cdfa8455083455713c92bd80f98368319ba03bf188064bfead129a07779ea76eL22-R22): Updated the `System.Text.Json` package reference from version `8.0.4` to `9.0.1` for `netstandard2.0`.