### PR TITLE
fix: dont return early for required map

### DIFF
--- a/src/LEGO.AsyncAPI/Writers/AsyncApiWriterExtensions.cs
+++ b/src/LEGO.AsyncAPI/Writers/AsyncApiWriterExtensions.cs
@@ -285,10 +285,7 @@ namespace LEGO.AsyncAPI.Writers
             Action<IAsyncApiWriter, string, T> action)
             where T : IAsyncApiElement
         {
-            if (elements != null && elements.Any())
-            {
-                writer.WriteMapInternal(name, elements, action);
-            }
+            writer.WriteMapInternal(name, elements, action);
         }
 
         /// <summary>

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -1325,5 +1325,37 @@ namespace LEGO.AsyncAPI.Tests
 
             Assert.AreEqual("this mah binding", httpBinding.Headers.Description);
         }
+
+
+
+        [Test]
+        public void SerializeV2_EmptyChannelObject_DeserializeAndSerializePreserveChannelObject()
+        {
+            // Arrange
+            var spec = """
+                asyncapi: 2.6.0
+                info:
+                  title: Spec with missing channel info
+                  description: test description
+                servers:
+                  production:
+                    url: example.com
+                    protocol: pulsar+ssl
+                    description: test description
+                channels: { }
+            """;
+
+            var settings = new AsyncApiReaderSettings();
+            settings.Bindings = BindingsCollection.All;
+            var reader = new AsyncApiStringReader(settings);
+
+            // Act
+            var deserialized = reader.Read(spec, out var diagnostic);
+            var actual = deserialized.Serialize(AsyncApiVersion.AsyncApi2_0, AsyncApiFormat.Yaml);
+
+            // Assert
+            actual.Should()
+                .BePlatformAgnosticEquivalentTo(spec);
+        }
     }
 }

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -1333,20 +1333,19 @@ namespace LEGO.AsyncAPI.Tests
         {
             // Arrange
             var spec = """
-                asyncapi: 2.6.0
-                info:
-                  title: Spec with missing channel info
-                  description: test description
-                servers:
-                  production:
-                    url: example.com
-                    protocol: pulsar+ssl
-                    description: test description
-                channels: { }
+            asyncapi: 2.6.0
+            info:
+              title: Spec with missing channel info
+              description: test description
+            servers:
+              production:
+                url: example.com
+                protocol: pulsar+ssl
+                description: test description
+            channels: { }
             """;
 
             var settings = new AsyncApiReaderSettings();
-            settings.Bindings = BindingsCollection.All;
             var reader = new AsyncApiStringReader(settings);
 
             // Act


### PR DESCRIPTION
## About the PR
Writing a required map should continue to writeInternal without the ability to return early on the if statement so it fails accordingly to the 'required rule'.

### Changelog
- Remove: Removed bug from the writer!
