### PR TITLE
fix: empty channels should be allowed

### DIFF
--- a/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
@@ -46,7 +46,7 @@ namespace LEGO.AsyncAPI.Models
         /// <summary>
         /// REQUIRED. The available channels and messages for the API.
         /// </summary>
-        public IDictionary<string, AsyncApiChannel> Channels { get; set; } = new Dictionary<string, AsyncApiChannel>();
+        public IDictionary<string, AsyncApiChannel> Channels { get; set; }
 
         /// <summary>
         /// an element to hold various schemas for the specification.

--- a/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
+++ b/src/LEGO.AsyncAPI/Models/AsyncApiDocument.cs
@@ -6,8 +6,8 @@ namespace LEGO.AsyncAPI.Models
     using System.Collections.Generic;
     using LEGO.AsyncAPI.Exceptions;
     using LEGO.AsyncAPI.Models.Interfaces;
-    using LEGO.AsyncAPI.Writers;
     using LEGO.AsyncAPI.Services;
+    using LEGO.AsyncAPI.Writers;
 
     /// <summary>
     /// This is the root document object for the API specification. It combines resource listing and API declaration together into one document.

--- a/src/LEGO.AsyncAPI/Validation/Rules/AsyncApiDocumentRules.cs
+++ b/src/LEGO.AsyncAPI/Validation/Rules/AsyncApiDocumentRules.cs
@@ -30,7 +30,7 @@ namespace LEGO.AsyncAPI.Validation.Rules
                     context.Exit();
 
                     context.Enter("channels");
-                    if (document.Channels == null || !document.Channels.Keys.Any())
+                    if (document.Channels == null)
                     {
                         context.CreateError(
                             nameof(DocumentRequiredFields),

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentBuilder.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentBuilder.cs
@@ -2,9 +2,10 @@
 
 namespace LEGO.AsyncAPI.Tests
 {
+    using System;
+    using System.Collections.Generic;
     using LEGO.AsyncAPI.Models;
     using LEGO.AsyncAPI.Models.Interfaces;
-    using System;
 
     internal class AsyncApiDocumentBuilder
     {
@@ -42,6 +43,10 @@ namespace LEGO.AsyncAPI.Tests
 
         public AsyncApiDocumentBuilder WithChannel(string key, AsyncApiChannel channel)
         {
+            if (this.document.Channels == null)
+            {
+                this.document.Channels = new Dictionary<string, AsyncApiChannel>();
+            }
             this.document.Channels.Add(key, channel);
             return this;
         }

--- a/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/LEGO.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -1202,6 +1202,10 @@ namespace LEGO.AsyncAPI.Tests
                     },
                 },
             };
+            if (doc.Channels == null)
+            {
+                doc.Channels = new Dictionary<string, AsyncApiChannel>();
+            }
             doc.Channels.Add(
                 "testChannel",
                 new AsyncApiChannel
@@ -1260,6 +1264,10 @@ namespace LEGO.AsyncAPI.Tests
                 Protocol = "pulsar+ssl",
                 Url = "example.com",
             });
+            if (doc.Channels == null)
+            {
+                doc.Channels = new Dictionary<string, AsyncApiChannel>();
+            }
             doc.Channels.Add(
                 "testChannel",
                 new AsyncApiChannel


### PR DESCRIPTION
## About the PR
This change updates the AsyncAPI document validation logic to allow an empty `channels` object (`channels: {}`) as valid. According to the AsyncAPI, the `channels` field is **required** in every document, but it may be empty. The validation now only checks for the presence of the `channels` field, not its contents.

**AsyncAPI Spec Reference:**  
The AsyncAPI standard requires the presence of the `channels` object, but does **not** require it to contain any channels (this is not specifically described). An empty object should be valid.
https://v2.asyncapi.com/docs/reference/specification/v2.6.0#channelsObject

More information to be found also here: https://github.com/LEGO/api-management-management-api/issues/3012

### Changelog
- Add: Added amazing features!
- Remove: Removed tedious bugs!

### Related Issues
- Closes #<issue-number>
